### PR TITLE
Allow to prepare response outside of Request

### DIFF
--- a/src/Response.php
+++ b/src/Response.php
@@ -1031,7 +1031,7 @@ class Response extends \yii\base\Response implements ResponseInterface
      * The default implementation will convert [[data]] into [[content]] and set headers accordingly.
      * @throws InvalidConfigException if the formatter for the specified format is invalid or [[format]] is not supported
      */
-    protected function prepare()
+    public function prepare()
     {
         if ($this->bodyRange !== null) {
             return;

--- a/src/Response.php
+++ b/src/Response.php
@@ -328,19 +328,29 @@ class Response extends \yii\base\Response implements ResponseInterface
 
     /**
      * Sends the response to the client.
+     * @param bool $return Send to stdout or return object. If set to `true` method will return prepared Response object.
+     * @return Response
+     * @throws HeadersAlreadySentException
+     * @throws InvalidConfigException
      */
-    public function send()
+    public function send($return = false)
     {
         if ($this->isSent) {
-            return;
+            return $this;
         }
+
         $this->trigger(self::EVENT_BEFORE_SEND);
         $this->prepare();
         $this->trigger(self::EVENT_AFTER_PREPARE);
-        $this->sendHeaders();
-        $this->sendContent();
+
+        if(!$return) {
+            $this->sendHeaders();
+            $this->sendContent();
+        }
+
         $this->trigger(self::EVENT_AFTER_SEND);
         $this->isSent = true;
+        return $this;
     }
 
     /**
@@ -1031,7 +1041,7 @@ class Response extends \yii\base\Response implements ResponseInterface
      * The default implementation will convert [[data]] into [[content]] and set headers accordingly.
      * @throws InvalidConfigException if the formatter for the specified format is invalid or [[format]] is not supported
      */
-    public function prepare()
+    protected function prepare()
     {
         if ($this->bodyRange !== null) {
             return;

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -11,6 +11,7 @@ use Error;
 use Exception;
 use RuntimeException;
 use yii\helpers\StringHelper;
+use yii\http\MemoryStream;
 use yii\web\HttpException;
 
 /**
@@ -93,6 +94,20 @@ class ResponseTest extends \yii\tests\TestCase
     protected function generateTestFileContent()
     {
         return '12ёжик3456798áèabcdefghijklmnopqrstuvwxyz!"§$%&/(ёжик)=?';
+    }
+
+    public function testSendToReturn()
+    {
+        $testBodyContent = "Test response";
+        $this->response->data = $testBodyContent;
+
+        ob_start();
+        $psrResponse = $this->response->send(true);
+        $content = ob_get_clean();
+
+        static::assertEquals('', $content);
+        static::assertEquals(200, $this->response->statusCode);
+        static::assertEquals($psrResponse->getBody()->getContents(), $testBodyContent);
     }
 
     /**


### PR DESCRIPTION
Hi!

This change required to receive body data for PSR-7 response passing (not echo).

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | none
