### PR TITLE
Fix CacheSession remove init()

### DIFF
--- a/src/CacheSession.php
+++ b/src/CacheSession.php
@@ -7,6 +7,8 @@
 
 namespace yii\web;
 
+use yii\base\Application;
+use yii\di\Initiable;
 use yii\helpers\Yii;
 use yii\cache\CacheInterface;
 use yii\di\Instance;
@@ -47,16 +49,12 @@ class CacheSession extends Session
      *
      * Starting from version 2.0.2, this can also be a configuration array for creating the object.
      */
-    public $cache = 'cache';
+    protected $cache = 'cache';
 
-
-    /**
-     * Initializes the application component.
-     */
-    public function init()
+    public function __construct(Application $app)
     {
-        parent::init();
-        $this->cache = Instance::ensure($this->cache, CacheInterface::class);
+        parent::__construct($app);
+        $this->setCache($this->cache);
     }
 
     /**
@@ -119,4 +117,22 @@ class CacheSession extends Session
     {
         return [__CLASS__, $id];
     }
+
+    /**
+     * @return CacheInterface
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * @param array|string|CacheInterface $cache
+     */
+    public function setCache($cache)
+    {
+        $factory = Yii::get('factory');
+        $this->cache = $factory->ensure($cache, CacheInterface::class);
+    }
+
 }

--- a/src/CacheSession.php
+++ b/src/CacheSession.php
@@ -8,10 +8,8 @@
 namespace yii\web;
 
 use yii\base\Application;
-use yii\di\Initiable;
 use yii\helpers\Yii;
 use yii\cache\CacheInterface;
-use yii\di\Instance;
 
 /**
  * CacheSession implements a session component using cache as storage medium.

--- a/tests/session/CacheSessionTest.php
+++ b/tests/session/CacheSessionTest.php
@@ -7,7 +7,6 @@
 
 namespace yii\web\tests\session;
 
-use yii\helpers\Yii;
 use yii\cache\ArrayCache;
 use yii\cache\Cache;
 use yii\web\CacheSession;

--- a/tests/session/CacheSessionTest.php
+++ b/tests/session/CacheSessionTest.php
@@ -21,12 +21,19 @@ class CacheSessionTest extends \yii\tests\TestCase
     {
         parent::setUp();
         $this->mockApplication();
-        $this->app->set('cache', new Cache(['handler' => new ArrayCache()]));
+        $this->container->setAll([
+            'cache' => [
+                '__class' => Cache::class,
+                '__construct()' => [
+                    'handler' => new ArrayCache()
+                ]
+            ]
+        ]);
     }
 
     public function testCacheSession()
     {
-        $session = new CacheSession();
+        $session = new CacheSession($this->app);
 
         $session->writeSession('test', 'sessionData');
         $this->assertEquals('sessionData', $session->readSession('test'));
@@ -37,7 +44,8 @@ class CacheSessionTest extends \yii\tests\TestCase
     public function testInvalidCache()
     {
         $this->expectException('\Exception');
-        new CacheSession(['cache' => 'invalid']);
+        $session = new CacheSession($this->app);
+        $session->setCache('invalid');
     }
 
     /**
@@ -45,7 +53,7 @@ class CacheSessionTest extends \yii\tests\TestCase
      */
     public function testNotWrittenSessionDestroying()
     {
-        $session = new CacheSession();
+        $session = new CacheSession($this->app);
 
         $session->set('foo', 'bar');
         $this->assertEquals('bar', $session->get('foo'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | yes
| Tests pass?   | yes
| Fixed issues  | 

'CacheSession' is updated, function `init` is removed, the type '$cashe' for protected is changed and getter/setter are added to it. 
`CacheSessionTest` is updated.