### PR TITLE
Add filter bind param int

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,6 +63,7 @@
         "source": "https://github.com/yiisoft/yii-web"
     },
     "require": {
+        "php": ">=7.0",
         "yiisoft/yii-core": "^3.0@dev",
         "yiisoft/view": "^3.0@dev",
         "psr/http-message": "^1.0"

--- a/src/Controller.php
+++ b/src/Controller.php
@@ -333,6 +333,18 @@ class Controller extends \yii\base\Controller implements ViewContextInterface
             if (array_key_exists($name, $params)) {
                 if ($param->isArray()) {
                     $args[] = $actionParams[$name] = (array) $params[$name];
+                } elseif ($param->getType() && $param->getType()->getName() === 'int') {
+                    try {
+                        $args[] = $actionParams[$name] = static::filterParamInt($params[$name]);
+                    } catch (\TypeError $e) {
+                        throw new BadRequestHttpException(Yii::t('yii', 'Invalid data received for parameter "{param}".', [
+                            'param' => $name,
+                        ]));
+                    } catch (\Exception $e) {
+                        throw new BadRequestHttpException(Yii::t('yii', 'Invalid data received for parameter "{param}".', [
+                            'param' => $name,
+                        ]));
+                    }
                 } elseif (!is_array($params[$name])) {
                     $args[] = $actionParams[$name] = $params[$name];
                 } else {
@@ -470,5 +482,16 @@ class Controller extends \yii\base\Controller implements ViewContextInterface
     public function refresh($anchor = '')
     {
         return $this->app->getResponse()->redirect($this->app->getRequest()->getUrl() . $anchor);
+    }
+    
+    /**
+     * Filtering request parameters for int type
+     *
+     * @param int $value Request parameter value
+     * @return int Processing result
+     */
+    private static function filterParamInt(int $value): int
+    {
+        return $value;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  |


Данный патч позволяет, в параметрах action указать тип int для в качестве принимаемого значения, пример:
public function actionView(int $id)

В случае если придет строка которую нельзя интерпретировать как int по правилам языка php, то будет ошибка Bad Request.

Это позволит упросить фильтрацию, и не создавать форму если необходимо отфильтровать только get параметры на определенные типы и передать его куда то дальше где указаны типы.