### PR TITLE
Remove double init() call CompositeUrlRule.php

### DIFF
--- a/src/CompositeUrlRule.php
+++ b/src/CompositeUrlRule.php
@@ -47,7 +47,6 @@ abstract class CompositeUrlRule extends BaseObject implements UrlRuleInterface, 
         if (!empty($config)) {
             AbstractContainer::configure($this, $config);
         }
-        $this->init();
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
