### PR TITLE
Use `Stream::__toString()` instead of `Stream::getContents`

### DIFF
--- a/src/ErrorHandler/HtmlRenderer.php
+++ b/src/ErrorHandler/HtmlRenderer.php
@@ -273,7 +273,7 @@ final class HtmlRenderer extends ThrowableRenderer
             }
         }
 
-        $output .= "\n" . $request->getBody()->getContents() . "\n\n";
+        $output .= "\n" . $request->getBody() . "\n\n";
 
         return '<pre>' . $this->htmlEncode(rtrim($output, "\n")) . '</pre>';
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | 
| Fixed issues  | 

One more fix to `renderRequest()`.
Use `(string)$request->getBody()` instead of `$request->getBody()->getContents()` as consequtive calls to `getContents()` return empty string without `$request->getBody()->seek(0)`
See:
https://github.com/Nyholm/psr7/blob/master/tests/RequestTest.php#L40
https://github.com/Nyholm/psr7/blob/master/src/Stream.php#L102
