### PR TITLE
Fix scheme detection

### DIFF
--- a/src/ServerRequestFactory.php
+++ b/src/ServerRequestFactory.php
@@ -100,8 +100,10 @@ final class ServerRequestFactory
     {
         $uri = $this->uriFactory->createUri();
 
-        if (isset($server['HTTPS'])) {
-            $uri = $uri->withScheme($server['HTTPS'] === 'on' ? 'https' : 'http');
+        if (isset($server['HTTPS']) && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            $uri = $uri->withScheme('https');
+        } else {
+            $uri = $uri->withScheme('http');
         }
 
         if (isset($server['HTTP_HOST'])) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | 
| Fixed issues  | 

When using `http` `$_SERVER['HTTPS']` can be not set or set to `off` and if `https` is used it can have any non-empty value.