### PR TITLE
add composer require for ^7.1 php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "minimum-stability": "dev",
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "psr/container": "1.0.0",
         "psr/container-implementation": "1.0.0",
         "psr/http-factory": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     },
     "minimum-stability": "dev",
     "require": {
+        "php": "^7.1",
         "psr/container": "1.0.0",
         "psr/container-implementation": "1.0.0",
         "psr/http-factory": "^1.0",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ❌
| Fixed issues  | -

Change PHP minimum version to 7.1.

In `README.md`:
 
> The minimum required PHP version of Yii 3.0 is PHP 7.1.

but `yiisoft/data` define minimum 7.2 of PHP:

https://github.com/yiisoft/data/blob/0ad1df059e2c7d24f15c1470283b811103f2eb52/composer.json#L17

