### PR TITLE
HeaderHelper:getValueAndParameters() quote fix #149

### DIFF
--- a/src/Helper/HeaderHelper.php
+++ b/src/Helper/HeaderHelper.php
@@ -21,6 +21,9 @@ final class HeaderHelper
         $output = [array_shift($parts)];
         foreach ($parts as $part) {
             [$key, $headerValue] = explode('=', $part, 2);
+            if (preg_match('/^"(?<value>.*)"$/', $headerValue, $matches) === 1) {
+                $headerValue = $matches['value'];
+            }
             $output[$key] = $headerValue;
         }
         return $output;

--- a/tests/Helper/HeaderHelperTest.php
+++ b/tests/Helper/HeaderHelperTest.php
@@ -15,6 +15,10 @@ class HeaderHelperTest extends TestCase
             'empty' => ['', []],
             'noParams' => ['test', ['test']],
             'withParams' => ['test;q=1.0;version=2', ['test', 'q' => '1.0', 'version' => '2']],
+            'witQuotedParameter' => [
+                'test;noqoute=test;qoute="test2"',
+                ['test', 'noqoute' => 'test', 'qoute' => 'test2']
+            ],
         ];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -

https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html

![HTTP 1 1  Protocol Parameters](https://user-images.githubusercontent.com/9432032/68917874-57da2d00-076c-11ea-97d5-af31bc617538.png)

![HTTP 1 1  Protocol Parameters](https://user-images.githubusercontent.com/9432032/68917896-6de7ed80-076c-11ea-996d-cbd08108fe17.png)

https://tools.ietf.org/html/rfc7239#section-6

> It is important to note that an IPv6 address and any nodename with
   node-port specified MUST be quoted, since ":" is not an allowed
   character in "token".

https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html

![RFC1341 MIME    7 The Multipart content type](https://user-images.githubusercontent.com/9432032/68918088-15652000-076d-11ea-82f5-995e68b3bf09.png)
