### PR TITLE
[WIP] ErrorCatcher with default content type

### DIFF
--- a/src/Middleware/ErrorCatcher.php
+++ b/src/Middleware/ErrorCatcher.php
@@ -31,6 +31,7 @@ final class ErrorCatcher implements MiddlewareInterface
         'text/xml' => XmlRenderer::class,
         'text/plain' => PlainTextRenderer::class,
         'text/html' => HtmlRenderer::class,
+        '*/*' => HtmlRenderer::class,
     ];
 
     public function __construct(ResponseFactoryInterface $responseFactory, ErrorHandler $errorHandler, ContainerInterface $container)
@@ -110,7 +111,7 @@ final class ErrorCatcher implements MiddlewareInterface
         } catch (\InvalidArgumentException $e) {
             // The Accept header contains an invalid q factor
         }
-        return 'text/html';
+        return '*/*';
     }
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -83,7 +83,8 @@ class ErrorCatcherTest extends TestCase
         $this->assertSame($expectedRendererOutput, $content);
     }
 
-    public function testDefaultContentType(): void {
+    public function testDefaultContentType(): void
+    {
         $factory = new Psr17Factory();
         $errorHandler = new ErrorHandler(new Logger(), new MockThrowableRenderer(self::DEFAULT_RENDERER_RESPONSE));
         $container = new Container();

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -55,7 +55,7 @@ class ErrorCatcherTest extends TestCase
         $errorHandler = new ErrorHandler(new Logger(), new MockThrowableRenderer(self::DEFAULT_RENDERER_RESPONSE));
         $container = new Container();
         $catcher = (new ErrorCatcher($factory, $errorHandler, $container))
-            ->withoutRenderers('text/html');
+            ->withoutRenderers('*/*');
         $requestHandler = (new MockRequestHandler())->setHandleExcaption(new \RuntimeException());
         $response = $catcher->process(new ServerRequest('GET', '/', ['Accept' => ['test/html']]), $requestHandler);
         $response->getBody()->rewind();

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -82,4 +82,23 @@ class ErrorCatcherTest extends TestCase
         $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
         $this->assertSame($expectedRendererOutput, $content);
     }
+
+//    public function testDefaultContentType(): void {
+//        $factory = new Psr17Factory();
+//        $errorHandler = new ErrorHandler(new Logger(), new MockThrowableRenderer(self::DEFAULT_RENDERER_RESPONSE));
+//        $container = new Container();
+//        $containerId = 'testRenderer';
+//        $catcher = (new ErrorCatcher($factory, $errorHandler, $container))
+//            ->withAddedRenderer('*/*', $containerId);
+//        $expectedRendererOutput = 'expectedRendereOutput';
+//        $container->set($containerId, new MockThrowableRenderer($expectedRendererOutput));
+//        $requestHandler = (new MockRequestHandler())->setHandleExcaption(new \RuntimeException());
+//        $response = $catcher->process(new ServerRequest('GET', '/', ['Accept' => ['test/test']]),
+//            $requestHandler);
+//        $response->getBody()->rewind();
+//        $content = $response->getBody()->getContents();
+//        $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
+//        $this->assertSame($expectedRendererOutput, $content);
+//
+//    }
 }

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -83,22 +83,22 @@ class ErrorCatcherTest extends TestCase
         $this->assertSame($expectedRendererOutput, $content);
     }
 
-//    public function testDefaultContentType(): void {
-//        $factory = new Psr17Factory();
-//        $errorHandler = new ErrorHandler(new Logger(), new MockThrowableRenderer(self::DEFAULT_RENDERER_RESPONSE));
-//        $container = new Container();
-//        $containerId = 'testRenderer';
-//        $catcher = (new ErrorCatcher($factory, $errorHandler, $container))
-//            ->withAddedRenderer('*/*', $containerId);
-//        $expectedRendererOutput = 'expectedRendereOutput';
-//        $container->set($containerId, new MockThrowableRenderer($expectedRendererOutput));
-//        $requestHandler = (new MockRequestHandler())->setHandleExcaption(new \RuntimeException());
-//        $response = $catcher->process(new ServerRequest('GET', '/', ['Accept' => ['test/test']]),
-//            $requestHandler);
-//        $response->getBody()->rewind();
-//        $content = $response->getBody()->getContents();
-//        $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
-//        $this->assertSame($expectedRendererOutput, $content);
-//
-//    }
+    public function testDefaultContentType(): void {
+        $factory = new Psr17Factory();
+        $errorHandler = new ErrorHandler(new Logger(), new MockThrowableRenderer(self::DEFAULT_RENDERER_RESPONSE));
+        $container = new Container();
+        $containerId = 'testRenderer';
+        $catcher = (new ErrorCatcher($factory, $errorHandler, $container))
+            ->withAddedRenderer('*/*', $containerId);
+        $expectedRendererOutput = 'expectedRendereOutput';
+        $container->set($containerId, new MockThrowableRenderer($expectedRendererOutput));
+        $requestHandler = (new MockRequestHandler())->setHandleExcaption(new \RuntimeException());
+        $response = $catcher->process(new ServerRequest('GET', '/', ['Accept' => ['test/test']]),
+            $requestHandler);
+        $response->getBody()->rewind();
+        $content = $response->getBody()->getContents();
+        $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
+        $this->assertSame($expectedRendererOutput, $content);
+
+    }
 }

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -80,7 +80,7 @@ class ErrorCatcherTest extends TestCase
         $response->getBody()->rewind();
         $content = $response->getBody()->getContents();
         $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
-        $this->assertSame($expectedRendererOutput, $content);
+        $this.ontent);
     }
 
     public function testDefaultContentType(): void
@@ -100,6 +100,5 @@ class ErrorCatcherTest extends TestCase
         $content = $response->getBody()->getContents();
         $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
         $this->assertSame($expectedRendererOutput, $content);
-
     }
 }

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -80,7 +80,6 @@ class ErrorCatcherTest extends TestCase
         $response->getBody()->rewind();
         $content = $response->getBody()->getContents();
         $this->assertNotSame(self::DEFAULT_RENDERER_RESPONSE, $content);
-        $this.ontent);
     }
 
     public function testDefaultContentType(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #155 

The #158 issue has a problem with the tests, which ruins a number of other tests. The `ErrorHandler` registers to error handler and causes problems in other tests. I don't know if this could cause a problem in the future.