### PR TITLE
Session adjustments

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,7 +10,8 @@
     convertWarningsToExceptions="true"
     stopOnFailure="false"
     executionOrder="random"
-    resolveDependencies="true">
+    resolveDependencies="true"
+    printerClass="Yiisoft\Yii\Web\Tests\ResultPrinter">
 
     <testsuites>
         <testsuite name="Yii Web Test Suite">

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -37,10 +37,6 @@ class Session implements SessionInterface
             $defaultOptions = array_merge($defaultOptions, self::DEFAULT_OPTIONS_73);
         }
         $this->options = array_merge($defaultOptions, $options);
-
-        if ($this->isActive()) {
-            throw new \RuntimeException('Session is already started');
-        }
     }
 
     public function get(string $key, $default = null)
@@ -166,5 +162,6 @@ class Session implements SessionInterface
     public function setId(string $sessionId): void
     {
         $this->sessionId = $sessionId;
+        session_id($sessionId);
     }
 }

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -162,6 +162,5 @@ class Session implements SessionInterface
     public function setId(string $sessionId): void
     {
         $this->sessionId = $sessionId;
-        session_id($sessionId);
     }
 }

--- a/tests/ResultPrinter.php
+++ b/tests/ResultPrinter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Yiisoft\Yii\Web\Tests;
+
+/**
+ * Class ResultPrinter overrides \PHPUnit\TextUI\ResultPrinter constructor
+ * to change default output to STDOUT and prevent some tests from fail when
+ * they can not be executed after headers have been sent.
+ */
+class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
+{
+    public function __construct(
+        $out = null,
+        $verbose = false,
+        $colors = \PHPUnit\TextUI\ResultPrinter::COLOR_DEFAULT,
+        $debug = false,
+        $numberOfColumns = 80,
+        $reverse = false
+    ) {
+        if ($out === null) {
+            $out = STDOUT;
+        }
+
+        parent::__construct($out, $verbose, $colors, $debug, $numberOfColumns, $reverse);
+    }
+
+    public function flush(): void
+    {
+        if ($this->out !== STDOUT) {
+            parent::flush();
+        }
+    }
+}

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -30,6 +30,7 @@ class SessionTest extends TestCase
         $session->close();
         self::assertEquals(PHP_SESSION_NONE, session_status());
 
+        $session->open();
         $session->destroy();
     }
 

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -12,6 +12,7 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->set('key_get', 'value');
         self::assertEquals('value', $session->get('key_get'));
+        $session->discard();
     }
 
     public function testHas(): void
@@ -19,6 +20,7 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->set('key_has', 'value');
         self::assertTrue($session->has('key_has'));
+        $session->discard();
     }
 
     public function testClose(): void
@@ -36,6 +38,7 @@ class SessionTest extends TestCase
         $id = $session->getId();
         $session->regenerateId();
         self::assertNotEquals($id, $session->getId());
+        $session->discard();
     }
 
     public function testDiscard(): void
@@ -44,12 +47,14 @@ class SessionTest extends TestCase
         $session->set('key_discard', 'value');
         $session->discard();
         self::assertEmpty($session->get('key_discard'));
+        $session->discard();
     }
 
     public function testGetName(): void
     {
         $session = new Session();
         self::assertEquals($session->getName(), session_name());
+        $session->discard();
     }
 
     public function testPull(): void
@@ -58,6 +63,7 @@ class SessionTest extends TestCase
         $session->set('key_pull', 'value');
         self::assertEquals('value', $session->pull('key_pull'));
         self::assertEmpty($session->get('key_pull'));
+        $session->discard();
     }
 
     public function testAll(): void
@@ -66,6 +72,7 @@ class SessionTest extends TestCase
         $session->set('key_1', 1);
         $session->set('key_2', 2);
         self::assertEquals(['key_1' => 1, 'key_2' => 2], $session->all());
+        $session->discard();
     }
 
     public function testClear(): void
@@ -74,6 +81,7 @@ class SessionTest extends TestCase
         $session->set('key', 'value');
         $session->clear();
         self::assertEmpty($session->all());
+        $session->discard();
     }
 
     public function testSetId(): void
@@ -82,6 +90,7 @@ class SessionTest extends TestCase
         $session->setId('sessionId');
         $session->open();
         self::assertEquals(session_id(), $session->getId());
+        $session->discard();
     }
 
     public function testGetCookieParameters(): void

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -12,7 +12,7 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->set('key_get', 'value');
         self::assertEquals('value', $session->get('key_get'));
-        $session->discard();
+        $session->destroy();
     }
 
     public function testHas(): void
@@ -20,7 +20,7 @@ class SessionTest extends TestCase
         $session = new Session();
         $session->set('key_has', 'value');
         self::assertTrue($session->has('key_has'));
-        $session->discard();
+        $session->destroy();
     }
 
     public function testClose(): void
@@ -29,6 +29,8 @@ class SessionTest extends TestCase
         $session->set('key_close', 'value');
         $session->close();
         self::assertEquals(PHP_SESSION_NONE, session_status());
+
+        $session->destroy();
     }
 
     public function testRegenerateID(): void
@@ -38,7 +40,7 @@ class SessionTest extends TestCase
         $id = $session->getId();
         $session->regenerateId();
         self::assertNotEquals($id, $session->getId());
-        $session->discard();
+        $session->destroy();
     }
 
     public function testDiscard(): void
@@ -47,14 +49,14 @@ class SessionTest extends TestCase
         $session->set('key_discard', 'value');
         $session->discard();
         self::assertEmpty($session->get('key_discard'));
-        $session->discard();
+        $session->destroy();
     }
 
     public function testGetName(): void
     {
         $session = new Session();
         self::assertEquals($session->getName(), session_name());
-        $session->discard();
+        $session->destroy();
     }
 
     public function testPull(): void
@@ -63,7 +65,7 @@ class SessionTest extends TestCase
         $session->set('key_pull', 'value');
         self::assertEquals('value', $session->pull('key_pull'));
         self::assertEmpty($session->get('key_pull'));
-        $session->discard();
+        $session->destroy();
     }
 
     public function testAll(): void
@@ -72,7 +74,7 @@ class SessionTest extends TestCase
         $session->set('key_1', 1);
         $session->set('key_2', 2);
         self::assertEquals(['key_1' => 1, 'key_2' => 2], $session->all());
-        $session->discard();
+        $session->destroy();
     }
 
     public function testClear(): void
@@ -81,7 +83,7 @@ class SessionTest extends TestCase
         $session->set('key', 'value');
         $session->clear();
         self::assertEmpty($session->all());
-        $session->discard();
+        $session->destroy();
     }
 
     public function testSetId(): void
@@ -90,7 +92,7 @@ class SessionTest extends TestCase
         $session->setId('sessionId');
         $session->open();
         self::assertEquals(session_id(), $session->getId());
-        $session->discard();
+        $session->destroy();
     }
 
     public function testGetCookieParameters(): void

--- a/tests/Session/SessionTest.php
+++ b/tests/Session/SessionTest.php
@@ -7,30 +7,21 @@ use PHPUnit\Framework\TestCase;
 
 class SessionTest extends TestCase
 {
-    /**
-     * @runInSeparateProcess
-     */
-    public function testGetAndSet()
+    public function testGetAndSet(): void
     {
         $session = new Session();
         $session->set('key_get', 'value');
         self::assertEquals('value', $session->get('key_get'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testHas()
+    public function testHas(): void
     {
         $session = new Session();
         $session->set('key_has', 'value');
         self::assertTrue($session->has('key_has'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testClose()
+    public function testClose(): void
     {
         $session = new Session();
         $session->set('key_close', 'value');
@@ -38,10 +29,7 @@ class SessionTest extends TestCase
         self::assertEquals(PHP_SESSION_NONE, session_status());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testRegenerateID()
+    public function testRegenerateID(): void
     {
         $session = new Session();
         $session->open();
@@ -50,10 +38,7 @@ class SessionTest extends TestCase
         self::assertNotEquals($id, $session->getId());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testDiscard()
+    public function testDiscard(): void
     {
         $session = new Session();
         $session->set('key_discard', 'value');
@@ -61,16 +46,13 @@ class SessionTest extends TestCase
         self::assertEmpty($session->get('key_discard'));
     }
 
-    public function testGetName()
+    public function testGetName(): void
     {
         $session = new Session();
         self::assertEquals($session->getName(), session_name());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testPull()
+    public function testPull(): void
     {
         $session = new Session();
         $session->set('key_pull', 'value');
@@ -78,10 +60,7 @@ class SessionTest extends TestCase
         self::assertEmpty($session->get('key_pull'));
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testAll()
+    public function testAll(): void
     {
         $session = new Session();
         $session->set('key_1', 1);
@@ -89,10 +68,7 @@ class SessionTest extends TestCase
         self::assertEquals(['key_1' => 1, 'key_2' => 2], $session->all());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testClear()
+    public function testClear(): void
     {
         $session = new Session();
         $session->set('key', 'value');
@@ -100,10 +76,7 @@ class SessionTest extends TestCase
         self::assertEmpty($session->all());
     }
 
-    /**
-     * @runInSeparateProcess
-     */
-    public function testSetId()
+    public function testSetId(): void
     {
         $session = new Session();
         $session->setId('sessionId');
@@ -111,19 +84,9 @@ class SessionTest extends TestCase
         self::assertEquals(session_id(), $session->getId());
     }
 
-    public function testGetCookieParameters()
+    public function testGetCookieParameters(): void
     {
         $session = new Session();
         self::assertEquals(session_get_cookie_params(), $session->getCookieParameters());
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testAlreadyStartedException()
-    {
-        $session = new Session();
-        $session->open();
-        new Session();
     }
 }


### PR DESCRIPTION
- Use custom result printer from Yii 2 not to interfere with output breaking session
- Remove test isolation
- Remove throwing exception when creating another instance of Session and session is already started

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | -
