### PR TITLE
Fix #93: Add non-verbose mode for ErrorHandler

### DIFF
--- a/src/ErrorHandler/ErrorCatcher.php
+++ b/src/ErrorHandler/ErrorCatcher.php
@@ -1,5 +1,5 @@
 <?php
-namespace Yiisoft\Yii\Web\Middleware;
+namespace Yiisoft\Yii\Web\ErrorHandler;
 
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -7,12 +7,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Yiisoft\Yii\Web\ErrorHandler\ErrorHandler;
-use Yiisoft\Yii\Web\ErrorHandler\ThrowableRendererInterface;
-use Yiisoft\Yii\Web\ErrorHandler\HtmlRenderer;
-use Yiisoft\Yii\Web\ErrorHandler\JsonRenderer;
-use Yiisoft\Yii\Web\ErrorHandler\PlainTextRenderer;
-use Yiisoft\Yii\Web\ErrorHandler\XmlRenderer;
 use Yiisoft\Yii\Web\Helper\HeaderHelper;
 
 /**
@@ -43,10 +37,10 @@ final class ErrorCatcher implements MiddlewareInterface
 
     public function withAddedRenderer(string $mimeType, string $rendererClass): self
     {
-        if (strlen($mimeType) === 0) {
+        if ($mimeType === '') {
             throw new \InvalidArgumentException('The mime type cannot be an empty string!');
         }
-        if (strlen($rendererClass) === 0) {
+        if ($rendererClass === '') {
             throw new \InvalidArgumentException('The renderer class cannot be an empty string!');
         }
         if (strpos($mimeType, '/') === false) {
@@ -68,7 +62,7 @@ final class ErrorCatcher implements MiddlewareInterface
             return $new;
         }
         foreach ($mimeTypes as $mimeType) {
-            if (strlen($mimeType) === 0) {
+            if ($mimeType === '') {
                 throw new \InvalidArgumentException('The mime type cannot be an empty string!');
             }
             unset($new->renderers[strtolower($mimeType)]);
@@ -102,8 +96,7 @@ final class ErrorCatcher implements MiddlewareInterface
     private function getContentType(ServerRequestInterface $request): string
     {
         try {
-            $acceptHeaders = HeaderHelper::getSortedAcceptTypesFromRequest($request);
-            foreach ($acceptHeaders as $header) {
+            foreach (HeaderHelper::getSortedAcceptTypesFromRequest($request) as $header) {
                 if (array_key_exists($header, $this->renderers)) {
                     return $header;
                 }

--- a/src/ErrorHandler/ErrorHandler.php
+++ b/src/ErrorHandler/ErrorHandler.php
@@ -134,7 +134,13 @@ final class ErrorHandler
         unset($this->memoryReserve);
         $error = error_get_last();
         if ($error !== null && ErrorException::isFatalError($error)) {
-            $exception = new ErrorException($error['message'], $error['type'], $error['type'], $error['file'], $error['line']);
+            $exception = new ErrorException(
+                $error['message'],
+                $error['type'],
+                $error['type'],
+                $error['file'],
+                $error['line']
+            );
             $this->handleThrowable($exception);
             exit(1);
         }
@@ -143,14 +149,26 @@ final class ErrorHandler
     private function log(\Throwable $t/*, ServerRequestInterface $request*/): void
     {
         $renderer = new PlainTextRenderer();
-        $this->logger->error($renderer->renderVerbose($t), [
-            'throwable' => $t,
-            //'request' => $request,
-        ]);
+        $this->logger->error(
+            $renderer->renderVerbose($t),
+            [
+                'throwable' => $t,
+                //'request' => $request,
+            ]
+        );
     }
 
-    public function setExposeDetails(bool $exposeDetails): void
+    public function withExposedDetails(): self
     {
-        $this->exposeDetails = $exposeDetails;
+        $new = clone $this;
+        $new->exposeDetails = true;
+        return $new;
+    }
+
+    public function withoutExposedDetails(): self
+    {
+        $new = clone $this;
+        $new->exposeDetails = false;
+        return $new;
     }
 }

--- a/src/ErrorHandler/ErrorHandler.php
+++ b/src/ErrorHandler/ErrorHandler.php
@@ -20,6 +20,8 @@ final class ErrorHandler
 
     private $defaultRenderer;
 
+    private $exposeDetails = true;
+
     public function __construct(LoggerInterface $logger, ThrowableRendererInterface $defaultRenderer)
     {
         $this->logger = $logger;
@@ -73,7 +75,7 @@ final class ErrorHandler
 
         try {
             $this->log($t);
-            return $renderer->render($t);
+            return $this->exposeDetails ? $renderer->renderVerbose($t) : $renderer->render($t);
         } catch (\Throwable $t) {
             return nl2br($t);
         }
@@ -141,9 +143,14 @@ final class ErrorHandler
     private function log(\Throwable $t/*, ServerRequestInterface $request*/): void
     {
         $renderer = new PlainTextRenderer();
-        $this->logger->error($renderer->render($t), [
+        $this->logger->error($renderer->renderVerbose($t), [
             'throwable' => $t,
             //'request' => $request,
         ]);
+    }
+
+    public function setExposeDetails(bool $exposeDetails): void
+    {
+        $this->exposeDetails = $exposeDetails;
     }
 }

--- a/src/ErrorHandler/HtmlRenderer.php
+++ b/src/ErrorHandler/HtmlRenderer.php
@@ -7,11 +7,31 @@ use Yiisoft\Yii\Web\Info;
 
 final class HtmlRenderer extends ThrowableRenderer
 {
-    // TODO expose config
     private $maxSourceLines = 19;
     private $maxTraceLines = 13;
 
     private $traceLine = '{html}';
+
+    public function withMaxSourceLines(int $maxSourceLines): self
+    {
+        $new = clone $this;
+        $new->maxSourceLines = $maxSourceLines;
+        return $new;
+    }
+
+    public function setMaxTraceLines(int $maxTraceLines): self
+    {
+        $new = clone $this;
+        $new->maxTraceLines = $maxTraceLines;
+        return $new;
+    }
+
+    public function withTraceLine(string $traceLine): self
+    {
+        $new = clone $this;
+        $new->traceLine = $traceLine;
+        return $new;
+    }
 
     public function render(\Throwable $t): string
     {
@@ -305,15 +325,16 @@ final class HtmlRenderer extends ThrowableRenderer
      */
     private function createServerInformationLink(): string
     {
-        $serverUrls = [
-            'http://httpd.apache.org/' => ['apache'],
-            'http://nginx.org/' => ['nginx'],
-            'http://lighttpd.net/' => ['lighttpd'],
-            'http://gwan.com/' => ['g-wan', 'gwan'],
-            'http://iis.net/' => ['iis', 'services'],
-            'https://secure.php.net/manual/en/features.commandline.webserver.php' => ['development'],
-        ];
         if (isset($_SERVER['SERVER_SOFTWARE'])) {
+            $serverUrls = [
+                'http://httpd.apache.org/' => ['apache'],
+                'http://nginx.org/' => ['nginx'],
+                'http://lighttpd.net/' => ['lighttpd'],
+                'http://gwan.com/' => ['g-wan', 'gwan'],
+                'http://iis.net/' => ['iis', 'services'],
+                'https://secure.php.net/manual/en/features.commandline.webserver.php' => ['development'],
+            ];
+
             foreach ($serverUrls as $url => $keywords) {
                 foreach ($keywords as $keyword) {
                     if (stripos($_SERVER['SERVER_SOFTWARE'], $keyword) !== false) {
@@ -332,6 +353,6 @@ final class HtmlRenderer extends ThrowableRenderer
      */
     public function createFrameworkVersionLink(): string
     {
-        return '<a href="http://github.com/yiisoft/yii2/" target="_blank">' . $this->htmlEncode(Info::frameworkVersion()) . '</a>';
+        return '<a href="http://github.com/yiisoft/yii-web/" target="_blank">' . $this->htmlEncode(Info::frameworkVersion()) . '</a>';
     }
 }

--- a/src/ErrorHandler/HtmlRenderer.php
+++ b/src/ErrorHandler/HtmlRenderer.php
@@ -19,7 +19,7 @@ final class HtmlRenderer extends ThrowableRenderer
         return $new;
     }
 
-    public function setMaxTraceLines(int $maxTraceLines): self
+    public function withMaxTraceLines(int $maxTraceLines): self
     {
         $new = clone $this;
         $new->maxTraceLines = $maxTraceLines;

--- a/src/ErrorHandler/HtmlRenderer.php
+++ b/src/ErrorHandler/HtmlRenderer.php
@@ -35,8 +35,8 @@ final class HtmlRenderer extends ThrowableRenderer
 
     public function render(\Throwable $t): string
     {
-        return $this->renderTemplate('exception', [
-            'throwable' => new \RuntimeException('An internal server error occurred.'),
+        return $this->renderTemplate('error', [
+            'throwable' => $t,
         ]);
     }
 

--- a/src/ErrorHandler/HtmlRenderer.php
+++ b/src/ErrorHandler/HtmlRenderer.php
@@ -16,6 +16,13 @@ final class HtmlRenderer extends ThrowableRenderer
     public function render(\Throwable $t): string
     {
         return $this->renderTemplate('exception', [
+            'throwable' => new \RuntimeException('An internal server error occurred.'),
+        ]);
+    }
+
+    public function renderVerbose(\Throwable $t): string
+    {
+        return $this->renderTemplate('exception', [
             'throwable' => $t,
         ]);
     }

--- a/src/ErrorHandler/JsonRenderer.php
+++ b/src/ErrorHandler/JsonRenderer.php
@@ -9,6 +9,13 @@ final class JsonRenderer extends ThrowableRenderer
     public function render(\Throwable $t): string
     {
         return json_encode([
+            'message' => 'An internal server error occurred',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES);
+    }
+
+    public function renderVerbose(\Throwable $t): string
+    {
+        return json_encode([
             'type' => get_class($t),
             'message' => $t->getMessage(),
             'code' => $t->getCode(),

--- a/src/ErrorHandler/PlainTextRenderer.php
+++ b/src/ErrorHandler/PlainTextRenderer.php
@@ -5,6 +5,11 @@ final class PlainTextRenderer extends ThrowableRenderer
 {
     public function render(\Throwable $t): string
     {
-        return  $this->convertThrowableToVerboseString($t);
+        return 'An internal server error occurred';
+    }
+
+    public function renderVerbose(\Throwable $t): string
+    {
+        return $this->convertThrowableToVerboseString($t);
     }
 }

--- a/src/ErrorHandler/ThrowableRendererInterface.php
+++ b/src/ErrorHandler/ThrowableRendererInterface.php
@@ -3,8 +3,26 @@ namespace Yiisoft\Yii\Web\ErrorHandler;
 
 use Psr\Http\Message\ServerRequestInterface;
 
+/**
+ * ThrowableRendererInterface converts throwable into its string representation
+ */
 interface ThrowableRendererInterface
 {
+    /**
+     * Convert throwable into its string representation suitable for displaying in production environment
+     *
+     * @param \Throwable $t
+     * @return string
+     */
     public function render(\Throwable $t): string;
+
+    /**
+     * Convert throwable into its string representation suitable for displaying in development environment
+     *
+     * @param \Throwable $t
+     * @return string
+     */
+    public function renderVerbose(\Throwable $t): string;
+
     public function setRequest(ServerRequestInterface $request): void;
 }

--- a/src/ErrorHandler/UserException.php
+++ b/src/ErrorHandler/UserException.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace Yiisoft\Yii\Web\ErrorHandler;
+
+/**
+ * UserException is the base class for exceptions that are meant to be shown to end users.
+ * Such exceptions are often caused by mistakes of end users.
+ */
+class UserException extends \Exception
+{
+
+}

--- a/src/ErrorHandler/UserException.php
+++ b/src/ErrorHandler/UserException.php
@@ -9,5 +9,4 @@ namespace Yiisoft\Yii\Web\ErrorHandler;
  */
 class UserException extends \Exception
 {
-
 }

--- a/src/ErrorHandler/XmlRenderer.php
+++ b/src/ErrorHandler/XmlRenderer.php
@@ -10,6 +10,15 @@ final class XmlRenderer extends ThrowableRenderer
     {
         $out = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>';
         $out .= "<error>\n";
+        $out .= $this->tag('message', 'An internal server error occurred');
+        $out .= '</error>';
+        return $out;
+    }
+
+    public function renderVerbose(\Throwable $t): string
+    {
+        $out = '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>';
+        $out .= "<error>\n";
         $out .= $this->tag('type', get_class($t));
         $out .= $this->tag('message', $this->cdata($t->getMessage()));
         $out .= $this->tag('code', $this->cdata($t->getCode()));

--- a/src/ErrorHandler/templates/error.php
+++ b/src/ErrorHandler/templates/error.php
@@ -9,13 +9,11 @@ use Yiisoft\Yii\Web\ErrorHandler\UserException;
 /* @var $throwable \Throwable */
 /* @var $this \Yiisoft\Yii\Web\ErrorHandler\HtmlRenderer */
 
-$name = $this->getThrowableName($throwable);
-if ($name === null) {
-    $name = 'Error';
-}
 if ($throwable instanceof UserException) {
+    $name = $this->getThrowableName($throwable);
     $message = $throwable->getMessage();
 } else {
+    $name = 'Error';
     $message = 'An internal server error occurred.';
 }
 ?>

--- a/src/ErrorHandler/templates/error.php
+++ b/src/ErrorHandler/templates/error.php
@@ -1,0 +1,80 @@
+<?php
+if (!isset($this)) {
+    // @link https://github.com/sebastianbergmann/phpunit/issues/3952
+    return;
+}
+
+use Yiisoft\Yii\Web\ErrorHandler\UserException;
+
+/* @var $throwable \Throwable */
+/* @var $this \Yiisoft\Yii\Web\ErrorHandler\HtmlRenderer */
+
+$name = $this->getThrowableName($throwable);
+if ($name === null) {
+    $name = 'Error';
+}
+if ($throwable instanceof UserException) {
+    $message = $throwable->getMessage();
+} else {
+    $message = 'An internal server error occurred.';
+}
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title><?= $this->htmlEncode($name) ?></title>
+
+    <style>
+        body {
+            font: normal 9pt "Verdana";
+            color: #000;
+            background: #fff;
+        }
+
+        h1 {
+            font: normal 18pt "Verdana";
+            color: #f00;
+            margin-bottom: .5em;
+        }
+
+        h2 {
+            font: normal 14pt "Verdana";
+            color: #800000;
+            margin-bottom: .5em;
+        }
+
+        h3 {
+            font: bold 11pt "Verdana";
+        }
+
+        p {
+            font: normal 9pt "Verdana";
+            color: #000;
+        }
+
+        .version {
+            color: gray;
+            font-size: 8pt;
+            border-top: 1px solid #aaa;
+            padding-top: 1em;
+            margin-bottom: 1em;
+        }
+    </style>
+</head>
+
+<body>
+    <h1><?= $this->htmlEncode($name) ?></h1>
+    <h2><?= nl2br($this->htmlEncode($message)) ?></h2>
+    <p>
+        The above error occurred while the Web server was processing your request.
+    </p>
+    <p>
+        Please contact us if you think this is a server error. Thank you.
+    </p>
+    <div class="version">
+        <?= date('Y-m-d H:i:s') ?>
+    </div>
+</body>
+</html>
+

--- a/src/ErrorHandler/templates/exception.php
+++ b/src/ErrorHandler/templates/exception.php
@@ -494,7 +494,7 @@ window.onload = function() {
                 code = callStackItem.getElementsByClassName('code-wrap')[0];
 
             if (typeof code !== 'undefined') {
-                code.style.display = window.getComputedStyle(code).display == 'block' ? 'none' : 'block';
+                code.style.display = window.getComputedStyle(code).display === 'block' ? 'none' : 'block';
                 refreshCallStackItemCode(callStackItem);
             }
         });
@@ -524,9 +524,6 @@ window.onload = function() {
     document.onmousedown = function() { document.getElementsByTagName('body')[0].classList.add('mousedown'); }
     document.onmouseup = function() { document.getElementsByTagName('body')[0].classList.remove('mousedown'); }
     </script>
-    <?php if (method_exists($this, 'endBody')): ?>
-        <?php $this->endBody() // to allow injecting code into body (mostly by Yii Debug Toolbar)?>
-    <?php endif ?>
 </body>
 
 </html>

--- a/tests/ErrorHandler/HtmlRendererTest.php
+++ b/tests/ErrorHandler/HtmlRendererTest.php
@@ -9,7 +9,7 @@ use Yiisoft\Yii\Web\ErrorHandler\HtmlRenderer;
 
 class HtmlRendererTest extends TestCase
 {
-    public function testSimple(): void
+    public function testNonVerboseOutput(): void
     {
         $renderer = new HtmlRenderer();
         $request = new ServerRequest('GET', '/', ['Accept' => ['text/html']]);
@@ -17,6 +17,19 @@ class HtmlRendererTest extends TestCase
         $exceptionMessage = 'exception-test-message';
         $exception = new \RuntimeException($exceptionMessage);
         $renderedOutput = $renderer->render($exception);
+        $this->assertContains('<html', $renderedOutput);
+        $this->assertNotContains(RuntimeException::class, $renderedOutput);
+        $this->assertNotContains($exceptionMessage, $renderedOutput);
+    }
+
+    public function testVerboseOutput(): void
+    {
+        $renderer = new HtmlRenderer();
+        $request = new ServerRequest('GET', '/', ['Accept' => ['text/html']]);
+        $renderer->setRequest($request);
+        $exceptionMessage = 'exception-test-message';
+        $exception = new \RuntimeException($exceptionMessage);
+        $renderedOutput = $renderer->renderVerbose($exception);
         $this->assertContains('<html', $renderedOutput);
         $this->assertContains(RuntimeException::class, $renderedOutput);
         $this->assertContains($exceptionMessage, $renderedOutput);

--- a/tests/Middleware/ErrorCatcherTest.php
+++ b/tests/Middleware/ErrorCatcherTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 use Yiisoft\Di\Container;
 use Yiisoft\Log\Logger;
 use Yiisoft\Yii\Web\ErrorHandler\ErrorHandler;
-use Yiisoft\Yii\Web\Middleware\ErrorCatcher;
+use Yiisoft\Yii\Web\ErrorHandler\ErrorCatcher;
 use Yiisoft\Yii\Web\Tests\Middleware\Mock\MockRequestHandler;
 use Yiisoft\Yii\Web\Tests\Middleware\Mock\MockThrowableRenderer;
 

--- a/tests/Middleware/Mock/MockThrowableRenderer.php
+++ b/tests/Middleware/Mock/MockThrowableRenderer.php
@@ -21,4 +21,9 @@ class MockThrowableRenderer extends ThrowableRenderer
     {
         return $this->response;
     }
+
+    public function renderVerbose(\Throwable $t): string
+    {
+        return $this->response;
+    }
 }


### PR DESCRIPTION
That would allow configuring it like the following:

```php
Yiisoft\Yii\Web\ErrorHandler\ErrorHandler::class => function (ContainerInterface $container) {
    $errorHandler = $container->get(ErrorHandler::class);
    return $errorHandler->withoutExposedDetails();
},
```

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #93
