### PR TITLE
Fix #115: Adjust HTTP response code for invalid CSRF token

### DIFF
--- a/src/Middleware/Csrf.php
+++ b/src/Middleware/Csrf.php
@@ -36,7 +36,7 @@ final class Csrf implements MiddlewareInterface
         if (!$this->validateCsrfToken($request, $token)) {
             $this->session->remove($this->name);
 
-            $response = $this->responseFactory->createResponse(400);
+            $response = $this->responseFactory->createResponse(403);
             $response->getBody()->write('Unable to verify your data submission.');
             return $response;
         }

--- a/src/Middleware/Csrf.php
+++ b/src/Middleware/Csrf.php
@@ -36,7 +36,7 @@ final class Csrf implements MiddlewareInterface
         if (!$this->validateCsrfToken($request, $token)) {
             $this->session->remove($this->name);
 
-            $response = $this->responseFactory->createResponse(403);
+            $response = $this->responseFactory->createResponse(422);
             $response->getBody()->write('Unable to verify your data submission.');
             return $response;
         }

--- a/tests/Middleware/CsrfTest.php
+++ b/tests/Middleware/CsrfTest.php
@@ -11,7 +11,6 @@ use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use TheSeer\Tokenizer\Token;
 use Yiisoft\Router\Method;
 use Yiisoft\Security\Random;
 use Yiisoft\Security\TokenMask;
@@ -79,31 +78,31 @@ final class CsrfTest extends TestCase
     /**
      * @test
      */
-    public function invalidTokenResultIn403()
+    public function invalidTokenResultIn422()
     {
         $middleware = $this->createCsrfMiddlewareWithToken($this->generateToken());
         $response = $middleware->process($this->createPostServerRequestWithBodyToken($this->generateToken()), $this->createRequestHandler());
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(422, $response->getStatusCode());
     }
 
     /**
      * @test
      */
-    public function emptyTokenInSessionResultIn403()
+    public function emptyTokenInSessionResultIn422()
     {
         $middleware = $this->createCsrfMiddlewareWithToken('');
         $response = $middleware->process($this->createPostServerRequestWithBodyToken($this->generateToken()), $this->createRequestHandler());
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(422, $response->getStatusCode());
     }
 
     /**
      * @test
      */
-    public function emptyTokenInRequestResultIn403()
+    public function emptyTokenInRequestResultIn422()
     {
         $middleware = $this->createCsrfMiddlewareWithToken($this->generateToken());
         $response = $middleware->process($this->createServerRequest(), $this->createRequestHandler());
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(422, $response->getStatusCode());
     }
 
     private function createServerRequest(string $method = Method::POST, array $bodyParams = [], array $headParams = []): ServerRequestInterface

--- a/tests/Middleware/CsrfTest.php
+++ b/tests/Middleware/CsrfTest.php
@@ -79,31 +79,31 @@ final class CsrfTest extends TestCase
     /**
      * @test
      */
-    public function invalidTokenResultIn400()
+    public function invalidTokenResultIn403()
     {
         $middleware = $this->createCsrfMiddlewareWithToken($this->generateToken());
         $response = $middleware->process($this->createPostServerRequestWithBodyToken($this->generateToken()), $this->createRequestHandler());
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(403, $response->getStatusCode());
     }
 
     /**
      * @test
      */
-    public function emptyTokenInSessionResultIn400()
+    public function emptyTokenInSessionResultIn403()
     {
         $middleware = $this->createCsrfMiddlewareWithToken('');
         $response = $middleware->process($this->createPostServerRequestWithBodyToken($this->generateToken()), $this->createRequestHandler());
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(403, $response->getStatusCode());
     }
 
     /**
      * @test
      */
-    public function emptyTokenInRequestResultIn400()
+    public function emptyTokenInRequestResultIn403()
     {
         $middleware = $this->createCsrfMiddlewareWithToken($this->generateToken());
         $response = $middleware->process($this->createServerRequest(), $this->createRequestHandler());
-        $this->assertEquals(400, $response->getStatusCode());
+        $this->assertEquals(403, $response->getStatusCode());
     }
 
     private function createServerRequest(string $method = Method::POST, array $bodyParams = [], array $headParams = []): ServerRequestInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | #115
