### PR TITLE
Fix Typed property User::$identity must not be accessed before initia…

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -205,7 +205,7 @@ class User
      */
     public function isGuest(): bool
     {
-        return $this->identity instanceof GuestIdentity;
+        return $this->getIdentity() instanceof GuestIdentity;
     }
 
     /**


### PR DESCRIPTION
Typed property Yiisoft\Yii\Web\User\User::$identity must not be accessed before initialization
when call `Yiisoft\Yii\Web\User\User::isGuest()`
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
