### PR TITLE
Fix User::isGuest() return user is not a guest

### DIFF
--- a/src/User/User.php
+++ b/src/User/User.php
@@ -205,7 +205,7 @@ class User
      */
     public function isGuest(): bool
     {
-        return $this->identity instanceof GuestIdentity;
+        return $this->getIdentity() instanceof GuestIdentity;
     }
 
     /**


### PR DESCRIPTION
If call User::isGuest() before getIdentity() or setIdentity this always returns the user is not a guest since identity is null and not an instance of GuestIdentity

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
