### PR TITLE
SapiEmitter now throws Exception when HTTP headers have been sent before emitter

### DIFF
--- a/src/Application.php
+++ b/src/Application.php
@@ -1,6 +1,7 @@
 <?php
 namespace Yiisoft\Yii\Web;
 
+use Exception;
 use Psr\Http\Message\ServerRequestInterface;
 use Yiisoft\Router\Method;
 use Yiisoft\Yii\Web\Emitter\EmitterInterface;
@@ -13,15 +14,9 @@ use Yiisoft\Yii\Web\ErrorHandler\ErrorHandler;
  */
 final class Application
 {
-    /**
-     * @var MiddlewareDispatcher
-     */
-    private $dispatcher;
+    private MiddlewareDispatcher $dispatcher;
 
-    /**
-     * @var EmitterInterface
-     */
-    private $emitter;
+    private EmitterInterface $emitter;
 
     /**
      * Application constructor.
@@ -36,6 +31,11 @@ final class Application
         $errorHandler->register();
     }
 
+    /**
+     * @param ServerRequestInterface $request
+     * @return bool
+     * @throws Exception
+     */
     public function handle(ServerRequestInterface $request): bool
     {
         $response = $this->dispatcher->dispatch($request);

--- a/src/Emitter/EmitterInterface.php
+++ b/src/Emitter/EmitterInterface.php
@@ -3,6 +3,7 @@
 namespace Yiisoft\Yii\Web\Emitter;
 
 use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Yii\Web\Exception\HeadersHaveBeenSentException;
 
 /**
  * Emitter takes PSR-7 ResponseInterface, formats and outputs it
@@ -13,6 +14,7 @@ interface EmitterInterface
      * @param ResponseInterface $response
      * @param bool $withoutBody if body should be omitted
      * @return bool whether the response have been outputted successfully
+     * @throws HeadersHaveBeenSentException
      */
     public function emit(ResponseInterface $response, bool $withoutBody = false): bool;
 }

--- a/src/Emitter/SapiEmitter.php
+++ b/src/Emitter/SapiEmitter.php
@@ -3,6 +3,7 @@
 namespace Yiisoft\Yii\Web\Emitter;
 
 use Psr\Http\Message\ResponseInterface;
+use Yiisoft\Yii\Web\Exception\HeadersHaveBeenSentException;
 
 /**
  * SapiEmitter sends a response using PHP Server API
@@ -12,7 +13,7 @@ final class SapiEmitter implements EmitterInterface
     private const NO_BODY_RESPONSE_CODES = [100, 101, 102, 204, 205, 304];
     private const DEFAULT_BUFFER_SIZE = 8388608; // 8MB
 
-    private $bufferSize;
+    private int $bufferSize;
 
     public function __construct(?int $bufferSize = null)
     {
@@ -28,31 +29,30 @@ final class SapiEmitter implements EmitterInterface
         $withoutBody = $withoutBody || !$this->shouldOutputBody($response);
         $withoutContentLength = $withoutBody || $response->hasHeader('Transfer-Encoding');
 
-        // we can't replace headers if they are already sent
-        if (!headers_sent()) {
-            header_remove();
-            // send HTTP Status-Line
-            header(sprintf(
-                'HTTP/%s %d %s',
-                $response->getProtocolVersion(),
-                $status,
-                $response->getReasonPhrase()
-            ), true, $status);
-            // filter headers
-            $headers = $withoutContentLength
-                ? $response->withoutHeader('Content-Length')
-                           ->getHeaders()
-                : $response->getHeaders();
-            // send headers
-            foreach ($headers as $header => $values) {
-                $replaceFirst = strtolower($header) !== 'set-cookie';
-                foreach ($values as $value) {
-                    header(sprintf('%s: %s', $header, $value), $replaceFirst);
-                    $replaceFirst = false;
-                }
+        // we can't send headers if they are already sent
+        if (headers_sent()) {
+            throw new HeadersHaveBeenSentException();
+        }
+        header_remove();
+        // send HTTP Status-Line
+        header(sprintf(
+            'HTTP/%s %d %s',
+            $response->getProtocolVersion(),
+            $status,
+            $response->getReasonPhrase()
+        ), true, $status);
+        // filter headers
+        $headers = $withoutContentLength
+            ? $response->withoutHeader('Content-Length')
+                       ->getHeaders()
+            : $response->getHeaders();
+        // send headers
+        foreach ($headers as $header => $values) {
+            $replaceFirst = strtolower($header) !== 'set-cookie';
+            foreach ($values as $value) {
+                header(sprintf('%s: %s', $header, $value), $replaceFirst);
+                $replaceFirst = false;
             }
-        } else {
-            $withoutContentLength = false;
         }
 
         if (!$withoutBody) {

--- a/src/Exception/HeadersHaveBeenSentException.php
+++ b/src/Exception/HeadersHaveBeenSentException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Yiisoft\Yii\Web\Exception;
+
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
+
+class HeadersHaveBeenSentException extends \Exception implements FriendlyExceptionInterface
+{
+    public function getName(): string
+    {
+        return 'HTTP headers have been sent';
+    }
+    public function getSolution(): ?string
+    {
+        \headers_sent($filename, $line);
+        return "Headers already sent in {$filename} on line {$line}\n"
+            . "Emitter can't send headers once the headers block has already been sent.";
+    }
+}

--- a/tests/Emitter/HTTPFunctions.php
+++ b/tests/Emitter/HTTPFunctions.php
@@ -16,6 +16,9 @@ class HTTPFunctions
     private static $headers = [];
     /** @var int */
     private static $responseCode = 200;
+    private static $headersSent = false;
+    private static string $headersSentFile = '';
+    private static int $headersSentLine = 0;
 
     /**
      * Reset state
@@ -24,6 +27,29 @@ class HTTPFunctions
     {
         self::$headers = [];
         self::$responseCode = 200;
+        self::$headersSent = false;
+        self::$headersSentFile = '';
+        self::$headersSentLine = 0;
+    }
+
+    /**
+     * Set header_sent() state
+     */
+    public static function set_headers_sent(bool $value = false, string $file = '', int $line = 0): void
+    {
+        static::$headersSent = $value;
+        static::$headersSentFile = $file;
+        static::$headersSentLine = $line;
+    }
+
+    /**
+     * Check if headers have been sent
+     */
+    public static function headers_sent(&$file = null, &$line = null): bool
+    {
+        $file = static::$headersSentFile;
+        $line = static::$headersSentLine;
+        return static::$headersSent;
     }
 
     /**

--- a/tests/Emitter/HTTPFunctionsTest.php
+++ b/tests/Emitter/HTTPFunctionsTest.php
@@ -24,6 +24,7 @@ class HTTPFunctionsTest extends TestCase
     {
         $this->assertEquals(200, $this->getResponseCode());
         $this->assertEquals([], $this->getHeaders());
+        $this->assertFalse(HTTPFunctions::headers_sent());
     }
 
     public function testHeaderAndHasHeader(): void
@@ -39,11 +40,24 @@ class HTTPFunctionsTest extends TestCase
     {
         HTTPFunctions::header('X-Test: 1');
         HTTPFunctions::header('X-Test: 2', false, 500);
+        HTTPFunctions::set_headers_sent(true, 'test', 123);
 
         HTTPFunctions::reset();
 
         $this->assertEquals(200, $this->getResponseCode());
         $this->assertEquals([], $this->getHeaders());
+        $this->assertFalse(HTTPFunctions::headers_sent($file, $line));
+        $this->assertEquals('', $file);
+        $this->assertEquals(0, $line);
+    }
+
+    public function testHeadersSent(): void
+    {
+        HTTPFunctions::set_headers_sent(true, 'path/to/test/file.php', 123);
+
+        $this->assertTrue(HTTPFunctions::headers_sent($file, $line));
+        $this->assertEquals('path/to/test/file.php', $file);
+        $this->assertEquals(123, $line);
     }
 
     public function testAddedHeaders(): void

--- a/tests/Emitter/SapiEmitterTest.php
+++ b/tests/Emitter/SapiEmitterTest.php
@@ -7,8 +7,11 @@ use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
 use Yiisoft\Yii\Web\Emitter\EmitterInterface;
 use Yiisoft\Yii\Web\Emitter\SapiEmitter;
+use Yiisoft\Yii\Web\Exception\HeadersHaveBeenSentException;
+
 
 /**
  * @runTestsInSeparateProcesses
@@ -134,6 +137,19 @@ class SapiEmitterTest extends TestCase
 
         $this->assertEquals(['Content-Length: ' . strlen($body)], $this->getHeaders());
         $this->expectOutputString($body);
+    }
+
+    /**
+     * @test
+     */
+    public function exceptionWhenHeadersHaveBeenSent(): void
+    {
+        $body = 'Example body';
+        $response = $this->createResponse(200, [], $body);
+        HTTPFunctions::set_headers_sent(true, 'test-file.php', 200);
+
+        $this->expectException(HeadersHaveBeenSentException::class);
+        $this->createEmitter()->emit($response);
     }
 
     /**

--- a/tests/Emitter/SapiEmitterTest.php
+++ b/tests/Emitter/SapiEmitterTest.php
@@ -12,7 +12,6 @@ use Yiisoft\Yii\Web\Emitter\EmitterInterface;
 use Yiisoft\Yii\Web\Emitter\SapiEmitter;
 use Yiisoft\Yii\Web\Exception\HeadersHaveBeenSentException;
 
-
 /**
  * @runTestsInSeparateProcesses
  */

--- a/tests/Emitter/httpFunctionMocks.php
+++ b/tests/Emitter/httpFunctionMocks.php
@@ -7,9 +7,9 @@ if (!function_exists(__NAMESPACE__ . '\\headers_sent')) {
     /**
      * Mock for the headers_sent() function for Emitter class.
      */
-    function headers_sent(): bool
+    function headers_sent(&$file = null, &$line = null): bool
     {
-        return false;
+        return HTTPFunctions::headers_sent($file, $line);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

