### PR TITLE
Fix action caller next middleware handling

### DIFF
--- a/src/Middleware/ActionCaller.php
+++ b/src/Middleware/ActionCaller.php
@@ -31,6 +31,8 @@ final class ActionCaller implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $controller = $this->container->get($this->class);
-        return (new Injector($this->container))->invoke([$controller, $this->method], [$request, $handler]);
+        $response = (new Injector($this->container))->invoke([$controller, $this->method], [$request, $handler]);
+        $handler->handle($request);
+        return $response;
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  |❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️

There is the next example.
Route
```php
Route::get('/')
            ->to(new ActionCaller(SiteController::class, 'index', $container))
            ->prepend(function (ServerRequestInterface $request, RequestHandlerInterface $handler) use ($container) {
                $response = $container->get(ResponseFactoryInterface::class)->createResponse();
                if (!empty($request->getQueryParams())) {
                    $response->getBody()->write('This route not allowed with query params');
                    return $response->withStatus(403);
                }
                $response = $handler->handle($request);
                $body = $response->getBody();
                $body->rewind();
                $content = $body->getContents();
                file_put_contents('log-body.txt', $content);
                return $response;
            })->then(function (ServerRequestInterface $request, RequestHandlerInterface $handler) use ($container) {
                file_put_contents('log-uri.txt', $request->getUri());
                $response = $container->get(ResponseFactoryInterface::class)->createResponse();
                return $response;
            })
            ->name('site/index'),
```
Action
```php
public function index(): ResponseInterface
{
    $response = $this->responseFactory->createResponse();
    $output = $this->render('index');
    $response->getBody()->write($output);
    return $response;
}
```
Don't be scared, this is just my test case:) The first middleware prepended in the prepend() method fires successfully. The second middleware prepended in the then() method does not.
Of cause, I can do like this and evrerything will be ok.
```php
public function index(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
{
    $response = $this->responseFactory->createResponse();
    $output = $this->render('index');

    $response->getBody()->write($output);
    $handler->handle($request);
    return $response;
}
```
But is it what we expect? I dont think so.

P.S. Basically I do not know why then() method is needed. Everything I want I can do with a prepended middleware.