### PR TITLE
Add stack to MiddlewareDispatcher

### DIFF
--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -18,17 +18,10 @@ final class MiddlewareDispatcher
     /**
      * @var MiddlewareInterface[]
      */
-    private $middlewares = [];
+    private array $middlewares = [];
 
-    /**
-     * @var RequestHandlerInterface|null
-     */
-    private $nextHandler;
-
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    private RequestHandlerInterface $nextHandler;
+    private ContainerInterface $container;
 
     /**
      * Contains a chain of middleware wrapped in handlers.
@@ -62,6 +55,10 @@ final class MiddlewareDispatcher
         array_unshift($this->middlewares, new Callback($callback, $this->container));
     }
 
+    /**
+     * @param callable|MiddlewareInterface $middleware
+     * @return self
+     */
     public function addMiddleware($middleware): self
     {
         if (is_callable($middleware)) {

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -102,8 +102,7 @@ final class MiddlewareDispatcher implements MiddlewareInterface
 
     private function getCallbackMiddleware(callable $callback, ContainerInterface $container)
     {
-        return new class($callback, $container) implements MiddlewareInterface
-        {
+        return new class($callback, $container) implements MiddlewareInterface {
             /**
              * @var callable a PHP callback matching signature of [[MiddlewareInterface::process()]].
              */

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -50,11 +50,6 @@ final class MiddlewareDispatcher
         $this->nextHandler = $nextHandler ?? new NotFoundHandler($responseFactory);
     }
 
-    private function addCallable(callable $callback): void
-    {
-        array_unshift($this->middlewares, new Callback($callback, $this->container));
-    }
-
     /**
      * @param callable|MiddlewareInterface $middleware
      * @return self
@@ -62,12 +57,14 @@ final class MiddlewareDispatcher
     public function addMiddleware($middleware): self
     {
         if (is_callable($middleware)) {
-            $this->addCallable($middleware);
-        } elseif ($middleware instanceof MiddlewareInterface) {
-            array_unshift($this->middlewares, $middleware);
-        } else {
+            $middleware = new Callback($middleware, $this->container);
+        }
+
+        if (!$middleware instanceof MiddlewareInterface) {
             throw new \InvalidArgumentException('Middleware should be either callable or MiddlewareInterface instance. ' . get_class($middleware) . ' given.');
         }
+
+        array_unshift($this->middlewares, $middleware);
 
         return $this;
     }

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -68,7 +68,7 @@ final class MiddlewareDispatcher implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->stack === null) {
-            foreach ($this->middlewares as $middleware ) {
+            foreach ($this->middlewares as $middleware) {
                 $handler = $this->wrap($middleware, $handler);
             }
             $this->stack = $handler;
@@ -99,7 +99,7 @@ final class MiddlewareDispatcher implements MiddlewareInterface
         };
     }
 
-    private function getCallbackMiddleware(callable $callback, ContainerInterface $container)
+    private function getCallbackMiddleware(callable $callback, ContainerInterface $container): MiddlewareInterface
     {
         return new class($callback, $container) implements MiddlewareInterface {
             /**

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -106,7 +106,7 @@ final class MiddlewareDispatcher implements MiddlewareInterface
              * @var callable a PHP callback matching signature of [[MiddlewareInterface::process()]].
              */
             private $callback;
-            private $container;
+            private ContainerInterface $container;
 
             public function __construct(callable $callback, ContainerInterface $container)
             {

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -38,19 +38,10 @@ final class MiddlewareDispatcher
     private ?RequestHandlerInterface $stack = null;
 
     public function __construct(
-        array $middlewares,
         ContainerInterface $container,
         RequestHandlerInterface $nextHandler = null
     ) {
-        if ($middlewares === []) {
-            throw new \InvalidArgumentException('Middlewares should be defined.');
-        }
-
         $this->container = $container;
-
-        for ($i = count($middlewares) - 1; $i >= 0; $i--) {
-            $this->addMiddleware($middlewares[$i]);
-        }
 
         $responseFactory = $container->get(ResponseFactoryInterface::class);
 
@@ -80,7 +71,7 @@ final class MiddlewareDispatcher
         return $this->process($request, $this->nextHandler);
     }
 
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    private function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->stack === null) {
             for ($i = count($this->middlewares) - 1; $i >= 0; $i--) {

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -9,7 +9,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Yiisoft\Injector\Injector;
-use Yiisoft\Yii\Web\Middleware\Callback;
 
 /**
  * MiddlewareDispatcher
@@ -56,7 +55,7 @@ final class MiddlewareDispatcher implements MiddlewareInterface
             throw new \InvalidArgumentException('Middleware should be either callable or MiddlewareInterface instance. ' . get_class($middleware) . ' given.');
         }
 
-        array_unshift($this->middlewares, $middleware);
+        $this->middlewares[] = $middleware;
 
         return $this;
     }
@@ -69,8 +68,8 @@ final class MiddlewareDispatcher implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->stack === null) {
-            for ($i = count($this->middlewares) - 1; $i >= 0; $i--) {
-                $handler = $this->wrap($this->middlewares[$i], $handler);
+            foreach ($this->middlewares as $middleware ) {
+                $handler = $this->wrap($middleware, $handler);
             }
             $this->stack = $handler;
         }

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -13,7 +13,7 @@ use Yiisoft\Yii\Web\Middleware\Callback;
 /**
  * MiddlewareDispatcher
  */
-final class MiddlewareDispatcher
+final class MiddlewareDispatcher implements MiddlewareInterface
 {
     /**
      * @var MiddlewareInterface[]
@@ -65,7 +65,7 @@ final class MiddlewareDispatcher
         return $this->process($request, $this->nextHandler);
     }
 
-    private function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         if ($this->stack === null) {
             for ($i = count($this->middlewares) - 1; $i >= 0; $i--) {

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -29,9 +29,9 @@ class MiddlewareDispatcherTest extends TestCase
     public function testAddThrowsInvalidArgumentExceptionWhenMiddlewareIsNotOfCorrectType(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $exampleInput = new SapiEmitter();
+        $incorrectInput = new SapiEmitter();
 
-        $this->middlewareDispatcher->addMiddleware($exampleInput);
+        $this->middlewareDispatcher->addMiddleware($incorrectInput);
     }
 
     /**
@@ -54,7 +54,7 @@ class MiddlewareDispatcherTest extends TestCase
         $this->middlewareDispatcher->addMiddleware($middleware);
     }
 
-    public function testDispatchCallsMiddlewareFullStack(): void
+    public function testDispatchExecutesMiddlewareStack(): void
     {
         $request = new ServerRequest('GET', '/');
         $this->fallbackHandlerMock

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -18,11 +18,6 @@ class MiddlewareDispatcherTest extends TestCase
     private ContainerInterface $containerMock;
     private RequestHandlerInterface $fallbackHandlerMock;
 
-    /**
-     * @var MiddlewareInterface[]
-     */
-    private array $middlewareMocks;
-
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -9,31 +9,19 @@ use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Yiisoft\Di\Container;
 use Yiisoft\Yii\Web\Emitter\SapiEmitter;
 use Yiisoft\Yii\Web\MiddlewareDispatcher;
 
 class MiddlewareDispatcherTest extends TestCase
 {
-    /**
-     * @var MiddlewareDispatcher
-     */
-    private $middlewareDispatcher;
-
-    /**
-     * @var Container
-     */
-    private $containerMock;
-
-    /**
-     * @var RequestHandlerInterface
-     */
-    private $fallbackHandlerMock;
+    private MiddlewareDispatcher $middlewareDispatcher;
+    private ContainerInterface $containerMock;
+    private RequestHandlerInterface $fallbackHandlerMock;
 
     /**
      * @var MiddlewareInterface[]
      */
-    private $middlewareMocks;
+    private array $middlewareMocks;
 
     public function setUp(): void
     {
@@ -93,11 +81,11 @@ class MiddlewareDispatcherTest extends TestCase
             ->method('handle')
             ->with($request);
 
-        $middleware1 = function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
+        $middleware1 = static function (ServerRequestInterface $request, RequestHandlerInterface $handler) {
             $request = $request->withAttribute('middleware', 'middleware1');
             return $handler->handle($request);
         };
-        $middleware2 = function (ServerRequestInterface $request) {
+        $middleware2 = static function (ServerRequestInterface $request) {
             return new Response(200, [], null, '1.1', implode($request->getAttributes()));
         };
         $middlewareDispatcher = new MiddlewareDispatcher([$middleware1, $middleware2], $this->containerMock, $this->fallbackHandlerMock);

--- a/tests/MiddlewareDispatcherTest.php
+++ b/tests/MiddlewareDispatcherTest.php
@@ -28,21 +28,7 @@ class MiddlewareDispatcherTest extends TestCase
         parent::setUp();
         $this->containerMock = $this->createMock(ContainerInterface::class);
         $this->fallbackHandlerMock = $this->createMock(RequestHandlerInterface::class);
-        $this->middlewareMocks = [
-            $this->createMock(MiddlewareInterface::class),
-            $this->createMock(MiddlewareInterface::class)
-        ];
-        $this->middlewareDispatcher = new MiddlewareDispatcher($this->middlewareMocks, $this->containerMock, $this->fallbackHandlerMock);
-    }
-
-    public function testConstructThrowsExceptionWhenMiddlewaresAreNotDefined(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        new MiddlewareDispatcher(
-            [],
-            $this->containerMock,
-            $this->fallbackHandlerMock
-        );
+        $this->middlewareDispatcher = new MiddlewareDispatcher($this->containerMock, $this->fallbackHandlerMock);
     }
 
     public function testAddThrowsInvalidArgumentExceptionWhenMiddlewareIsNotOfCorrectType(): void
@@ -88,8 +74,9 @@ class MiddlewareDispatcherTest extends TestCase
         $middleware2 = static function (ServerRequestInterface $request) {
             return new Response(200, [], null, '1.1', implode($request->getAttributes()));
         };
-        $middlewareDispatcher = new MiddlewareDispatcher([$middleware1, $middleware2], $this->containerMock, $this->fallbackHandlerMock);
-        $response = $middlewareDispatcher->dispatch($request);
+
+        $this->middlewareDispatcher->addMiddleware($middleware2)->addMiddleware($middleware1);
+        $response = $this->middlewareDispatcher->dispatch($request);
 
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('middleware1', $response->getReasonPhrase());


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️

You have to change `MiddlewareDispatcherFactory` in `yii-demo` after this PR.
 
```php
class MiddlewareDispatcherFactory
{
    public function __invoke(ContainerInterface $container)
    {
        $session = $container->get(SessionMiddleware::class);
        $router = $container->get(Router::class);
        $errorCatcher = $container->get(ErrorCatcher::class);
        $subFolder = $container->get(SubFolder::class);
        $dispatcher = new MiddlewareDispatcher($container);

        return $dispatcher
            ->addMiddleware($router)
            ->addMiddleware($subFolder)
            ->addMiddleware($session)
            ->addMiddleware($errorCatcher);
    }
}
```