### PR TITLE
Refactor Cookie, add CookieCollection

### DIFF
--- a/.phpstorm.meta.php/Cookie.php
+++ b/.phpstorm.meta.php/Cookie.php
@@ -3,7 +3,7 @@
 namespace PHPSTORM_META {
 
     expectedArguments(
-        \Yiisoft\Yii\Web\Cookie::sameSite(),
+        \Yiisoft\Yii\Web\Cookie::withSameSite(),
         0,
         argumentsSet('\Yiisoft\Yii\Web\Cookie::SAME_SITE'),
     );

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -20,37 +20,39 @@ use function in_array;
 use function preg_match;
 use function preg_split;
 use function strtolower;
+use function time;
 
 /**
- * Cookie helps adding Set-Cookie header response in order to set cookie
+ * Represent a cookie and also helps adding Set-Cookie header response in order to set cookie
  */
 final class Cookie
 {
     /**
      * Regular Expression used to validate cookie name
-     * @see https://tools.ietf.org/html/rfc6265#section-4.1.1
-     * @see https://tools.ietf.org/html/rfc2616#section-2.2
+     * @link https://tools.ietf.org/html/rfc6265#section-4.1.1
+     * @link https://tools.ietf.org/html/rfc2616#section-2.2
      */
-    private const TOKEN = '/^[a-zA-Z0-9!#$%&\' * +\- .^_`|~]+$/';
+    private const PATTERN_TOKEN = '/^[a-zA-Z0-9!#$%&\' * +\- .^_`|~]+$/';
 
     /**
      * Regular expression used to validate cooke value
-     * @see https://tools.ietf.org/html/rfc6265#section-4.1.1
-     * @see https://tools.ietf.org/html/rfc2616#section-2.2
+     * @link https://tools.ietf.org/html/rfc6265#section-4.1.1
+     * @link https://tools.ietf.org/html/rfc2616#section-2.2
      */
-    private const OCTET='/^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*$/';
+    private const PATTERN_OCTET='/^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*$/';
 
     /**
-     * SameSite policy Lax will prevent the cookie from being sent by the browser in all cross-site browsing context
+     * SameSite policy `Lax` will prevent the cookie from being sent by the browser in all cross-site browsing contexts
      * during CSRF-prone request methods (e.g. POST, PUT, PATCH etc).
      * E.g. a POST request from https://otherdomain.com to https://yourdomain.com will not include the cookie, however a GET request will.
-     * When a user follows a link from https://otherdomain.com to https://yourdomain.com it will include the cookie
+     * When a user follows a link from https://otherdomain.com to https://yourdomain.com it will include the cookie.
+     * This is the default value in modern browsers.
      * @see $sameSite
      */
     public const SAME_SITE_LAX = 'Lax';
 
     /**
-     * SameSite policy Strict will prevent the cookie from being sent by the browser in all cross-site browsing context
+     * SameSite policy `Strict` will prevent the cookie from being sent by the browser in all cross-site browsing contexts
      * regardless of the request method and even when following a regular link.
      * E.g. a GET request from https://otherdomain.com to https://yourdomain.com or a user following a link from
      * https://otherdomain.com to https://yourdomain.com will not include the cookie.
@@ -58,206 +60,395 @@ final class Cookie
      */
     public const SAME_SITE_STRICT = 'Strict';
 
+    /**
+     * SameSite policy `None` cookies will be sent in all contexts, i.e. sending cross-origin is allowed.
+     * `None` requires the `Secure` attribute in latest browser versions.
+     * @see $sameSite
+     */
     public const SAME_SITE_NONE = 'None';
 
     /**
-     * @var string name of the cookie
+     * @var string name of the cookie.
+     * A cookie name can be any US-ASCII characters, except control characters, spaces, or tabs.
+     * It also must not contain a separator character like the following: ( ) < > @ , ; : \ " / [ ] ? = { }
      */
     private string $name;
 
     /**
-     * @var string value of the cookie
+     * @var string value of the cookie.
+     * A cookie value can include any US-ASCII characters excluding control characters, whitespaces,
+     * double quotes, comma, semicolon, and backslash.
+     * If you wish to store arbitrary data in a value, you should encode that data.
+     * Value will be decoded when parsed from response.
+     * @see urlencode()
      */
     private string $value;
 
     /**
-     * @var DateTimeInterface|null RFC-1123 date at which the cookie expires.
-     * @see https://tools.ietf.org/html/rfc6265#section-4.1.1
+     * @var DateTimeInterface|null The maximum lifetime of the cookie.
+     * If unspecified, the cookie becomes a session cookie, which will be removed
+     * when the client shuts down.
+     * @link https://tools.ietf.org/html/rfc6265#section-4.1.1
+     * @link https://tools.ietf.org/html/rfc1123#page-55
      */
-    private ?DateTimeInterface $expire = null;
+    private ?DateTimeInterface $expires = null;
 
     /**
-     * @var int|null maximum age of cookie in seconds
-     */
-    private ?int $maxAge = null;
-
-    /**
-     * @var string|null domain of the cookie.
+     * @var string|null host/domain to which the cookie will be sent.
+     * If omitted, client will default to the host of the current URL, not including subdomains.
+     * Multiple host/domain values are not allowed, but if a domain is specified,
+     * then subdomains are always included.
      */
     private ?string $domain = null;
 
     /**
      * @var string|null the path on the server in which the cookie will be available on.
+     * A cookie path can include any US-ASCII characters excluding control characters and semicolon
      */
     private ?string $path = null;
 
     /**
-     * @var bool|null whether cookie should be sent via secure connection
+     * @var bool|null whether cookie should be sent via secure connection.
+     * A secure cookie is only sent to the server when a request is made with the https: scheme.
      */
     private ?bool $secure = null;
 
     /**
      * @var bool|null whether the cookie should be accessible only through the HTTP protocol.
      * By setting this property to true, the cookie will not be accessible by scripting languages,
-     * such as JavaScript, which can effectively help to reduce identity theft through XSS attacks.
+     * such as JavaScript, which can effectively help to mitigate attacks against cross-site scripting (XSS).
      */
     private ?bool $httpOnly = null;
 
     /**
-     * @var string|null SameSite prevents the browser from sending this cookie along with cross-site requests.
+     * @var string|null asserts that a cookie must not be sent with cross-origin requests.
+     * This provides some protection against cross-site request forgery attacks (CSRF)
      * @see https://cheatsheetseries.owasp.org/cheatsheets/Cross-Site_Request_Forgery_Prevention_Cheat_Sheet.html#samesite-cookie-attribute for more information about sameSite.
      */
     private ?string $sameSite = null;
 
-    public function __construct(string $name, string $value = '', bool $safeDefaults = true)
+    /**
+     * Cookie constructor.
+     *
+     * @param string $name The name of the cookie
+     * @param string $value The value of of the cookie
+     * @param DateTimeInterface|null $expires The time the cookie expires
+     * @param string|null $domain The path on the server in which cookie will be available on
+     * @param string|null $path The host/domain that the cookie is available to
+     * @param bool|null $secure Whether the client should send back the cookie only over HTTPS connection
+     * @param bool|null $httpOnly Whether the cookie should be accessible only through the HTTP protocol
+     * @param string|null $sameSite Whether the cookie should be available for cross-site requests
+     *
+     * @throws InvalidArgumentException when one or more arguments are not valid
+     */
+    public function __construct(
+        string $name,
+        string $value = '',
+        ?DateTimeInterface $expires = null,
+        ?string $domain = null,
+        ?string $path = '/',
+        ?bool $secure = true,
+        ?bool $httpOnly = true,
+        ?string $sameSite = self::SAME_SITE_LAX)
     {
-        if (!preg_match(self::TOKEN, $name)) {
-            throw new InvalidArgumentException("The cookie name \"$name\" contains invalid characters.");
+        if (!preg_match(self::PATTERN_TOKEN, $name)) {
+            throw new InvalidArgumentException("The cookie name \"$name\" contains invalid characters or is empty.");
         }
 
         $this->name = $name;
         $this->setValue($value);
-
-        if ($safeDefaults) {
-            $this->path = '/';
-            $this->secure = true;
-            $this->httpOnly = true;
-            $this->sameSite = self::SAME_SITE_LAX;
-        }
+        $this->expires = $expires !== null ? clone $expires : null;
+        $this->domain = $domain;
+        $this->setPath($path);
+        $this->secure = $secure;
+        $this->httpOnly = $httpOnly;
+        $this->setSameSite($sameSite);
     }
 
+    /**
+     * Gets the name of the cookie.
+     *
+     * @return string
+     */
     public function getName(): string
     {
         return $this->name;
     }
 
+    /**
+     * Creates a cookie copy with a new value.
+     *
+     * @param $value string value of the cookie.
+     * @return static
+     * @see $value for more information.
+     */
+    public function withValue(string $value): self
+    {
+        $new = clone $this;
+        $new->setValue($value);
+        return $new;
+    }
+
+    /**
+     * Gets the value of the cookie.
+     *
+     * @return string
+     */
     public function getValue(): string
     {
         return $this->value;
     }
 
-    public function isExpired(): bool
-    {
-        return isset($this->expire) && $this->expire->getTimestamp() < (new DateTimeImmutable())->getTimestamp();
-    }
-
-    public function expireAt(DateTimeInterface $dateTime): self
-    {
-        $new = clone $this;
-        $new->expire = $dateTime;
-        return $new;
-    }
-
-    public function expire(): self
-    {
-        return $this->expireAt((new \DateTimeImmutable('-5 years')));
-    }
-
-    public function maxAge(DateInterval $dateInterval): self
-    {
-        $reference = new DateTimeImmutable();
-        $expireDateTime = $reference->add($dateInterval);
-
-        $new = clone $this;
-        $new->expire = $expireDateTime;
-        $new->maxAge = $expireDateTime->getTimestamp() - $reference->getTimestamp();
-        return $new;
-    }
-
-    public function expireWhenBrowserIsClosed(): self
-    {
-        $new = clone $this;
-        $new->expire = null;
-        return $new;
-    }
-
-    public function domain(string $domain): self
-    {
-        $new = clone $this;
-        $new->domain = $domain;
-        return $new;
-    }
-
-    public function path(string $path): self
-    {
-        // path value is defined as any character except CTLs or ";"
-        if (preg_match('/[\x00-\x1F\x7F\x3B]/', $path)) {
-            throw new InvalidArgumentException("The cookie path \"$path\" contains invalid characters.");
-        }
-
-        $new = clone $this;
-        $new->path = $path;
-        return $new;
-    }
-
-    public function secure(bool $secure): self
-    {
-        $new = clone $this;
-        $new->secure = $secure;
-        return $new;
-    }
-
-    public function httpOnly(bool $httpOnly): self
-    {
-        $new = clone $this;
-        $new->httpOnly = $httpOnly;
-        return $new;
-    }
-
-    public function sameSite(string $sameSite): self
-    {
-        if (!in_array($sameSite, [self::SAME_SITE_LAX, self::SAME_SITE_STRICT, self::SAME_SITE_NONE], true)) {
-            throw new InvalidArgumentException('sameSite should be one of "Lax", "Strict" or "None"');
-        }
-
-        $new = clone $this;
-
-        if ($sameSite === self::SAME_SITE_NONE) {
-            // the secure flag is required for cookies that are marked as 'SameSite=None'
-            // so that cross-site cookies can only be accessed over HTTPS
-            // without it cookie will not be available for external access
-            $new->secure = true;
-        }
-
-        $new->sameSite = $sameSite;
-        return $new;
-    }
-
     private function setValue(string $value): void
     {
-        // @see https://tools.ietf.org/html/rfc6265#section-4.1.1
-        if (!preg_match(self::OCTET, $value)) {
+        // @link https://tools.ietf.org/html/rfc6265#section-4.1.1
+        if (!preg_match(self::PATTERN_OCTET, $value)) {
             throw new InvalidArgumentException("The cookie value \"$value\" contains invalid characters.");
         }
 
         $this->value = $value;
     }
 
+    /**
+     * Creates a cookie copy with a new time the cookie expires.
+     *
+     * @param DateTimeInterface $dateTime
+     * @return static
+     * @see $expires for more inforemation.
+     */
+    public function withExpires(DateTimeInterface $dateTime): self
+    {
+        $new = clone $this;
+        // Defensively clone the object to prevent further change
+        $new->expires = clone $dateTime;
+        return $new;
+    }
+
+    /**
+     * Gets the expiry of the cookie.
+     *
+     * @return DateTimeImmutable|null
+     */
+    public function getExpires(): ?DateTimeImmutable
+    {
+        // Can be replaced with DateTimeImmutable::createFromInterface in PHP 8
+        return $this->expires !== null ? (new DateTimeImmutable())->setTimestamp($this->expires->getTimestamp()) : null;
+    }
+
+    /**
+     * Indicates whether the cookie is expired.
+     * The cookie is expired when it has outdated `Expires`, or
+     * zero or negative `Max-Age` attributes
+     *
+     * @return bool whether the cookie is expired
+     */
+    public function isExpired(): bool
+    {
+        return $this->expires !== null && $this->expires->getTimestamp() < time();
+    }
+
+    /**
+     * Creates a cookie copy with a new lifetime set.
+     * If zero or negative interval is passed, the cookie will expire immediately.
+     *
+     * @param DateInterval $interval interval until the cookie expires.
+     * @return static
+     */
+    public function withMaxAge(DateInterval $interval): self
+    {
+        $new = clone $this;
+        $new->expires = (new DateTimeImmutable())->add($interval);
+        return $new;
+    }
+
+    /**
+     * Will remove the expiration from the cookie which will convert the cookie
+     * to session cookie, which will expire as soon as the browser is close.
+     *
+     * @return static
+     */
+    public function expireWhenBrowserIsClosed(): self
+    {
+        $new = clone $this;
+        $new->expires = null;
+        return $new;
+    }
+
+
+    /**
+     * Creates a cookie copy with a new domain set.
+     *
+     * @param string $domain
+     * @return static
+     */
+    public function withDomain(string $domain): self
+    {
+        $new = clone $this;
+        $new->domain = $domain;
+        return $new;
+    }
+
+    /**
+     * Gets the domain of the cookie.
+     *
+     * @return string|null
+     */
+    public function getDomain(): ?string
+    {
+        return $this->domain;
+    }
+
+    /**
+     * Creates a cookie copy with a new path set.
+     *
+     * @param string $path to be set for the cookie
+     * @return static
+     * @see $path for more information.
+     */
+    public function withPath(string $path): self
+    {
+        $new = clone $this;
+        $new->setPath($path);
+        return $new;
+    }
+
+    private function setPath(?string $path): void
+    {
+        if ($path !== null && preg_match('/[\x00-\x1F\x7F\x3B]/', $path)) {
+            throw new InvalidArgumentException("The cookie path \"$path\" contains invalid characters.");
+        }
+
+        $this->path = $path;
+    }
+
+    /**
+     * Gets the path of the cookie
+     *
+     * @return string|null
+     */
+    public function getPath(): ?string
+    {
+        return $this->path;
+    }
+
+    /**
+     * Creates a cookie copy by making it secure or insecure.
+     *
+     * @param bool $secure whether the cookie must be secure.
+     * @return static
+     */
+    public function withSecure(bool $secure = true): self
+    {
+        $new = clone $this;
+        $new->secure = $secure;
+        return $new;
+    }
+
+    /**
+     * Whether the cookie is secure.
+     *
+     * @return bool
+     */
+    public function isSecure(): bool
+    {
+        return $this->secure ?? false;
+    }
+
+    /**
+     * Creates a cookie copy that would be accessible only through the HTTP protocol.
+     *
+     * @param bool $httpOnly
+     * @return static
+     */
+    public function withHttpOnly(bool $httpOnly = true): self
+    {
+        $new = clone $this;
+        $new->httpOnly = $httpOnly;
+        return $new;
+    }
+
+    /**
+     * Whether the cookie can be accessed only through the HTTP protocol.
+     *
+     * @return bool
+     */
+    public function isHttpOnly(): bool
+    {
+        return $this->httpOnly ?? false;
+    }
+
+    /**
+     * Creates a cookie copy with SameSite attribute.
+     *
+     * @param string $sameSite
+     * @return static
+     */
+    public function withSameSite(string $sameSite): self
+    {
+        $new = clone $this;
+        $new->setSameSite($sameSite);
+        return $new;
+    }
+
+    private function setSameSite(?string $sameSite): void
+    {
+        if ($sameSite !== null
+            && !in_array($sameSite, [self::SAME_SITE_LAX, self::SAME_SITE_STRICT, self::SAME_SITE_NONE], true)) {
+            throw new InvalidArgumentException('sameSite should be one of "Lax", "Strict" or "None"');
+        }
+
+        if ($sameSite === self::SAME_SITE_NONE) {
+            // the secure flag is required for cookies that are marked as 'SameSite=None'
+            // so that cross-site cookies can only be accessed over HTTPS
+            // without it cookie will not be available for external access
+            $this->secure = true;
+        }
+
+        $this->sameSite = $sameSite;
+    }
+
+    /**
+     * Gets the SameSite attribute
+     *
+     * @return string|null
+     */
+    public function getSameSite(): ?string
+    {
+        return $this->sameSite;
+    }
+
+    /**
+     * Adds the cookie to the response and returns it.
+     *
+     * @param ResponseInterface $response
+     * @return ResponseInterface response with added cookie.
+     */
     public function addToResponse(ResponseInterface $response): ResponseInterface
     {
         return $response->withAddedHeader('Set-Cookie', (string) $this);
     }
 
+    /**
+     * Returns the cookie as a string.
+     *
+     * @return string The cookie
+     */
     public function __toString(): string
     {
         $cookieParts = [
             $this->name . '=' . $this->value
         ];
 
-        if ($this->expire) {
-            $cookieParts[] = 'Expires=' . $this->expire->format(DateTimeInterface::RFC7231);
+        if ($this->expires !== null) {
+            $cookieParts[] = 'Expires=' . $this->expires->format(DateTimeInterface::RFC7231);
+            $cookieParts[] = 'Max-Age=' . ($this->expires->getTimestamp() - time());
         }
 
-        // max-age must be non-zero digit
-        if ($this->maxAge && $this->maxAge > 0) {
-            $cookieParts[] = 'Max-Age=' . $this->maxAge;
-        }
-
-        if ($this->domain) {
+        if ($this->domain !== null) {
             $cookieParts[] = 'Domain=' . $this->domain;
         }
 
-        if ($this->path) {
+        if ($this->path !== null) {
             $cookieParts[] = 'Path=' . $this->path;
         }
 
@@ -269,7 +460,7 @@ final class Cookie
             $cookieParts[] = 'HttpOnly';
         }
 
-        if ($this->sameSite) {
+        if ($this->sameSite !== null) {
             $cookieParts[] = 'SameSite=' . $this->sameSite;
         }
 
@@ -277,27 +468,39 @@ final class Cookie
     }
 
     /**
-     * Parse 'Set-Cookie' string and build Cookie object.
-     * Pass only Set-Cookie header value.
+     * Parse `Set-Cookie` string and build Cookie object.
      *
-     * @param string $string 'Set-Cookie' header value
-     * @return self
+     * @param string $string `Set-Cookie` header value to parse
+     * @return static
      * @throws Exception
      */
-    public static function fromSetCookieString(string $string): self
+    public static function fromCookieString(string $string): self
     {
+        $rawAttributes = preg_split('~\s*[;]\s*~', $string);
+        if ($rawAttributes === false) {
+            throw new InvalidArgumentException('Failed to parse Set-Cookie string ' . $string);
+        }
         // array_filter with empty callback is used to filter out all falsy values
-        $rawAttributes = array_filter(preg_split('~\s*[;]\s*~', $string));
+        $rawAttributes = array_filter($rawAttributes);
 
         $rawAttribute = array_shift($rawAttributes);
 
         if (!is_string($rawAttribute)) {
-            throw new InvalidArgumentException('Cookie string must have at least on attribute');
+            throw new InvalidArgumentException('Cookie string must have at least name');
         }
 
         [$cookieName, $cookieValue] = self::splitCookieAttribute($rawAttribute);
 
-        $cookie = new self($cookieName, $cookieValue ?? '', false);
+        $params = [
+            'name' => $cookieName,
+            'value' => $cookieValue ?? '',
+            'expires' => null,
+            'domain' => null,
+            'path' => null,
+            'secure' => null,
+            'httpOnly' => null,
+            'sameSite' => null,
+        ];
 
         while ($rawAttribute = array_shift($rawAttributes)) {
             [$attributeKey, $attributeValue] = self::splitCookieAttribute($rawAttribute);
@@ -309,30 +512,30 @@ final class Cookie
 
             switch (strtolower($attributeKey)) {
                 case 'expires':
-                    $cookie = $cookie->expireAt(new DateTimeImmutable($attributeValue));
+                    $params['expires'] = new DateTimeImmutable($attributeValue);
                     break;
                 case 'max-age':
-                    $cookie = $cookie->maxAge(new DateInterval('PT' . $attributeValue . 'S'));
+                    $params['expires'] = (new DateTimeImmutable())->setTimestamp(time() + (int) $attributeValue);
                     break;
                 case 'domain':
-                    $cookie = $cookie->domain($attributeValue);
+                    $params['domain'] = $attributeValue;
                     break;
                 case 'path':
-                    $cookie = $cookie->path($attributeValue);
+                    $params['path'] = $attributeValue;
                     break;
                 case 'secure':
-                    $cookie = $cookie->secure(true);
+                    $params['secure'] = true;
                     break;
                 case 'httponly':
-                    $cookie = $cookie->httpOnly(true);
+                    $params['httpOnly'] = true;
                     break;
                 case 'samesite':
-                    $cookie = $cookie->sameSite($attributeValue);
+                    $params['sameSite'] = $attributeValue;
                     break;
             }
         }
 
-        return $cookie;
+        return new self(...array_values($params));
     }
 
     private static function splitCookieAttribute(string $attribute): array

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -149,8 +149,7 @@ final class Cookie
         ?bool $secure = true,
         ?bool $httpOnly = true,
         ?string $sameSite = self::SAME_SITE_LAX
-    )
-    {
+    ) {
         if (!preg_match(self::PATTERN_TOKEN, $name)) {
             throw new InvalidArgumentException("The cookie name \"$name\" contains invalid characters or is empty.");
         }

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -23,7 +23,7 @@ use function strtolower;
 use function time;
 
 /**
- * Represent a cookie and also helps adding Set-Cookie header response in order to set cookie
+ * Represents a cookie and also helps adding Set-Cookie header to response in order to set a cookie.
  */
 final class Cookie
 {
@@ -262,8 +262,19 @@ final class Cookie
     }
 
     /**
+     * Returns modified cookie that will expire immediately.
+     * @return static
+     */
+    public function expire(): self
+    {
+        $new = clone $this;
+        $new->expires = new DateTimeImmutable('-1 year');
+        return $new;
+    }
+
+    /**
      * Will remove the expiration from the cookie which will convert the cookie
-     * to session cookie, which will expire as soon as the browser is close.
+     * to session cookie, which will expire as soon as the browser is closed.
      *
      * @return static
      */

--- a/src/Cookie.php
+++ b/src/Cookie.php
@@ -550,8 +550,8 @@ final class Cookie
             $params['expires'] ?? null,
             $params['domain'] ?? null,
             $params['path'] ?? null,
-            $params['secure'] ?? false,
-            $params['httpOnly'] ?? false,
+            $params['secure'] ?? null,
+            $params['httpOnly'] ?? null,
             $params['sameSite'] ?? null
         );
     }

--- a/src/CookieCollection.php
+++ b/src/CookieCollection.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Web;
+
+use ArrayAccess;
+use ArrayIterator;
+use Closure;
+use Countable;
+use DateTimeImmutable;
+use InvalidArgumentException;
+use IteratorAggregate;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+use function array_keys;
+use function array_values;
+use function count;
+use function in_array;
+
+/**
+ * A CookieCollection is a collection implementation to wrap an array of Cookie class instances
+ */
+final class CookieCollection implements IteratorAggregate, ArrayAccess, Countable
+{
+    /**
+     * @var Cookie[] the cookies in this collection (indexed by the cookie name)
+     */
+    private array $cookies = [];
+
+    /**
+     * CookieCollection constructor.
+     * @param array $cookies the cookies that this collection initially contains.
+     */
+    public function __construct(array $cookies = [])
+    {
+        foreach ($cookies as $cookie) {
+            if (!($cookie instanceof Cookie)) {
+                throw new InvalidArgumentException('CookieCollection can contain only Cookie instances.');
+            }
+
+            $this->cookies[$cookie->getName()] = $cookie;
+        }
+    }
+
+    /**
+     * Returns the collection as a PHP array.
+     * The array keys are cookie names, and the array values are the corresponding cookie objects.
+     */
+    public function toArray(): array
+    {
+        return $this->cookies;
+    }
+
+    /**
+     * Returns an iterator for traversing the cookies in the collection.
+     * This method is required by the SPL interface [[\IteratorAggregate]].
+     * It will be implicitly called when you use `foreach` to traverse the collection.
+     */
+    public function getIterator(): \Traversable
+    {
+        return new ArrayIterator($this->cookies);
+    }
+
+    /**
+     * Returns whether there is a cookie with the specified name.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `isset($collection[$name])`.
+     * This is equivalent to [[has()]].
+     * @param string $name the cookie name
+     * @return bool whether the named cookie exists
+     */
+    public function offsetExists($name): bool
+    {
+        return $this->has($name);
+    }
+
+    /**
+     * Returns the cookie with the specified name.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `$cookie = $collection[$name];`.
+     * This is equivalent to [[get()]].
+     * @param string $name the cookie name
+     * @return Cookie the cookie with the specified name, null if the named cookie does not exist.
+     */
+    public function offsetGet($name): Cookie
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Adds the cookie to the collection.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `$collection[$name] = $cookie;`.
+     * This is equivalent to [[add()]].
+     * @param string $name the cookie name
+     * @param Cookie $cookie the cookie to be added
+     */
+    public function offsetSet($name, $cookie): void
+    {
+        $this->add($cookie);
+    }
+
+    /**
+     * Removes the named cookie.
+     * This method is required by the SPL interface [[\ArrayAccess]].
+     * It is implicitly called when you use something like `unset($collection[$name])`.
+     * This is equivalent to [[remove()]].
+     * @param string $name the cookie name
+     */
+    public function offsetUnset($name): void
+    {
+        $this->remove($name);
+    }
+
+    /**
+     * Returns the number of cookies in the collection.
+     * This method is required by the SPL `Countable` interface.
+     * It will be implicitly called when you use `count($collection)`.
+     * @return int the number of cookies in the collection.
+     */
+    public function count(): int
+    {
+        return count($this->cookies);
+    }
+
+    /**
+     * Returns the cookie with the specified name.
+     * @param string $name the cookie name
+     * @return Cookie the cookie with the specified name. Null if the named cookie does not exist.
+     * @see getValue()
+     */
+    public function get(string $name): Cookie
+    {
+        return $this->cookies[$name];
+    }
+
+    /**
+     * Returns the value of the named cookie.
+     * @param string $name the cookie name
+     * @param mixed $defaultValue the value that should be returned when the named cookie does not exist.
+     * @return mixed the value of the named cookie.
+     * @see get()
+     */
+    public function getValue(string $name, $defaultValue = null): ?string
+    {
+        return isset($this->cookies[$name]) ? $this->cookies[$name]->getValue() : $defaultValue;
+    }
+
+    /**
+     * Adds a cookie to the collection.
+     * If there is already a cookie with the same name in the collection, it will be removed first.
+     * @param Cookie $cookie the cookie to be added
+     */
+    public function add(Cookie $cookie): void
+    {
+        $this->cookies[$cookie->getName()] = $cookie;
+    }
+
+    /**
+     * Returns whether there is a cookie with the specified name.
+     * @param string $name the cookie name
+     * @return bool whether the named cookie exists
+     * @see remove()
+     */
+    public function has(string $name): bool
+    {
+        return isset($this->cookies[$name]);
+    }
+
+    /**
+     * Removes a cookie.
+     * @param string $name the name of the cookie to be removed.
+     * @return Cookie|null cookie that is removed
+     */
+    public function remove(string $name): ?Cookie
+    {
+        if (!isset($this->cookies[$name])) {
+            return null;
+        }
+
+        $removed = $this->cookies[$name];
+        unset($this->cookies[$name]);
+
+        return $removed;
+    }
+
+    /**
+     * Set cookie expire date to outdated to further remove it from browser.
+     * @param string $name the name of the cookie to expire.
+     */
+    public function expire(string $name): void
+    {
+        if (!isset($this->cookies[$name])) {
+            return;
+        }
+
+        $this->cookies[$name] = $this->cookies[$name]->expire();
+    }
+
+    /**
+     * Removes all cookies.
+     */
+    public function clear(): void
+    {
+        $this->cookies = [];
+    }
+
+    /**
+     * Returns whether the collection already contains the cookie.
+     * @param Cookie $cookie the cookie to check for
+     * @return bool whether cookie exists
+     * @see has()
+     */
+    public function contains(Cookie $cookie): bool
+    {
+        return in_array($cookie, $this->cookies, true);
+    }
+
+    /**
+     * Tests for the existence of the cookie that satisfies the given predicate.
+     * @param Closure $p The predicate.
+     * @return bool whether the predicate is true for at least on cookie.
+     */
+    public function exists(Closure $p): bool
+    {
+        foreach ($this->cookies as $name => $cookie) {
+            if ($p($name, $cookie)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Gets all names/indices of the collection.
+     * @return array<int, string> The names/indices of the collection.
+     */
+    public function getNames(): array
+    {
+        return array_keys($this->cookies);
+    }
+
+    /**
+     * Gets all cookies of the collection as an indexed array.
+     * @return array The cookie in the collection, in the order they appear in the collection.
+     */
+    public function getCookies(): array
+    {
+        return array_values($this->cookies);
+    }
+
+    /**
+     * Checks whether the collection is empty (contains no cookies).
+     * @return bool whether the collection is empty.
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->cookies);
+    }
+
+    /**
+     * Populates the cookie collection from an array of 'name' => 'value' pairs.
+     * @param array $array the cookies to populate from
+     * @return self collection created from array
+     */
+    public static function fromArray(array $array): self
+    {
+        // check if associative array with 'name' => 'value' pairs is passed
+        if (count(array_filter(array_keys($array), 'is_string')) === 0) {
+            throw new InvalidArgumentException('Array in wrong format is passed.');
+        }
+
+        $elements = [];
+        foreach ($array as $name => $value) {
+            $elements[$name] = new Cookie($name, $value);
+        }
+
+        return new self($elements);
+    }
+
+    /**
+     * Populates the cookie collection from a ResponseInterface.
+     * @param ResponseInterface $response the response object to populate from
+     * @return self collection created from response
+     */
+    public static function fromResponse(ResponseInterface $response): self
+    {
+        $collection = new self();
+        foreach ($response->getHeader('Set-Cookie') as $setCookieString) {
+            $cookie = Cookie::fromSetCookieString($setCookieString);
+            $collection->add($cookie);
+        }
+        return $collection;
+    }
+}

--- a/src/CookieCollection.php
+++ b/src/CookieCollection.php
@@ -8,7 +8,6 @@ use ArrayAccess;
 use ArrayIterator;
 use Closure;
 use Countable;
-use DateTimeImmutable;
 use Exception;
 use InvalidArgumentException;
 use IteratorAggregate;
@@ -20,8 +19,7 @@ use function count;
 use function in_array;
 
 /**
- * A CookieCollection is a collection implementation to wrap an array of Cookie class instances.
- * It also helps to work with many cookies at once and, to read and modify cookies from response.
+ * A CookieCollection helps to work with many cookies at once and to read / modify response cookies.
  *
  * @see Cookie
  */
@@ -202,20 +200,6 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
         unset($this->cookies[$name]);
 
         return $removed;
-    }
-
-    /**
-     * Set cookie expire date to outdated to further remove it from browser.
-     *
-     * @param string $name the name of the cookie to expire.
-     */
-    public function expire(string $name): void
-    {
-        if (!isset($this->cookies[$name])) {
-            return;
-        }
-
-        $this->cookies[$name] = $this->cookies[$name]->withExpires(new DateTimeImmutable('-1 year'));
     }
 
     /**

--- a/src/CookieCollection.php
+++ b/src/CookieCollection.php
@@ -9,10 +9,10 @@ use ArrayIterator;
 use Closure;
 use Countable;
 use DateTimeImmutable;
+use Exception;
 use InvalidArgumentException;
 use IteratorAggregate;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Http\Message\ServerRequestInterface;
 
 use function array_keys;
 use function array_values;
@@ -20,7 +20,10 @@ use function count;
 use function in_array;
 
 /**
- * A CookieCollection is a collection implementation to wrap an array of Cookie class instances
+ * A CookieCollection is a collection implementation to wrap an array of Cookie class instances.
+ * It also helps to work with many cookies at once and, to read and modify cookies from response.
+ *
+ * @see Cookie
  */
 final class CookieCollection implements IteratorAggregate, ArrayAccess, Countable
 {
@@ -31,6 +34,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * CookieCollection constructor.
+     *
      * @param array $cookies the cookies that this collection initially contains.
      */
     public function __construct(array $cookies = [])
@@ -47,6 +51,8 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
     /**
      * Returns the collection as a PHP array.
      * The array keys are cookie names, and the array values are the corresponding cookie objects.
+     *
+     * @return Cookie[]
      */
     public function toArray(): array
     {
@@ -57,8 +63,10 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * Returns an iterator for traversing the cookies in the collection.
      * This method is required by the SPL interface [[\IteratorAggregate]].
      * It will be implicitly called when you use `foreach` to traverse the collection.
+     *
+     * @return ArrayIterator
      */
-    public function getIterator(): \Traversable
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->cookies);
     }
@@ -68,6 +76,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `isset($collection[$name])`.
      * This is equivalent to [[has()]].
+     *
      * @param string $name the cookie name
      * @return bool whether the named cookie exists
      */
@@ -81,6 +90,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `$cookie = $collection[$name];`.
      * This is equivalent to [[get()]].
+     *
      * @param string $name the cookie name
      * @return Cookie the cookie with the specified name, null if the named cookie does not exist.
      */
@@ -94,6 +104,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `$collection[$name] = $cookie;`.
      * This is equivalent to [[add()]].
+     *
      * @param string $name the cookie name
      * @param Cookie $cookie the cookie to be added
      */
@@ -107,6 +118,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * This method is required by the SPL interface [[\ArrayAccess]].
      * It is implicitly called when you use something like `unset($collection[$name])`.
      * This is equivalent to [[remove()]].
+     *
      * @param string $name the cookie name
      */
     public function offsetUnset($name): void
@@ -118,6 +130,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * Returns the number of cookies in the collection.
      * This method is required by the SPL `Countable` interface.
      * It will be implicitly called when you use `count($collection)`.
+     *
      * @return int the number of cookies in the collection.
      */
     public function count(): int
@@ -127,6 +140,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Returns the cookie with the specified name.
+     *
      * @param string $name the cookie name
      * @return Cookie the cookie with the specified name. Null if the named cookie does not exist.
      * @see getValue()
@@ -138,9 +152,10 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Returns the value of the named cookie.
+     *
      * @param string $name the cookie name
      * @param mixed $defaultValue the value that should be returned when the named cookie does not exist.
-     * @return mixed the value of the named cookie.
+     * @return string|null the value of the named cookie or the default value if cookie is not set.
      * @see get()
      */
     public function getValue(string $name, $defaultValue = null): ?string
@@ -151,6 +166,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
     /**
      * Adds a cookie to the collection.
      * If there is already a cookie with the same name in the collection, it will be removed first.
+     *
      * @param Cookie $cookie the cookie to be added
      */
     public function add(Cookie $cookie): void
@@ -160,6 +176,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Returns whether there is a cookie with the specified name.
+     *
      * @param string $name the cookie name
      * @return bool whether the named cookie exists
      * @see remove()
@@ -171,6 +188,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Removes a cookie.
+     *
      * @param string $name the name of the cookie to be removed.
      * @return Cookie|null cookie that is removed
      */
@@ -188,6 +206,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Set cookie expire date to outdated to further remove it from browser.
+     *
      * @param string $name the name of the cookie to expire.
      */
     public function expire(string $name): void
@@ -196,7 +215,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
             return;
         }
 
-        $this->cookies[$name] = $this->cookies[$name]->expire();
+        $this->cookies[$name] = $this->cookies[$name]->withExpires(new DateTimeImmutable('-1 year'));
     }
 
     /**
@@ -209,6 +228,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Returns whether the collection already contains the cookie.
+     *
      * @param Cookie $cookie the cookie to check for
      * @return bool whether cookie exists
      * @see has()
@@ -220,6 +240,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Tests for the existence of the cookie that satisfies the given predicate.
+     *
      * @param Closure $p The predicate.
      * @return bool whether the predicate is true for at least on cookie.
      */
@@ -236,7 +257,8 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Gets all names/indices of the collection.
-     * @return array<int, string> The names/indices of the collection.
+     *
+     * @return array The names/indices of the collection.
      */
     public function getNames(): array
     {
@@ -245,6 +267,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Gets all cookies of the collection as an indexed array.
+     *
      * @return array The cookie in the collection, in the order they appear in the collection.
      */
     public function getCookies(): array
@@ -254,6 +277,7 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Checks whether the collection is empty (contains no cookies).
+     *
      * @return bool whether the collection is empty.
      */
     public function isEmpty(): bool
@@ -263,8 +287,9 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
 
     /**
      * Populates the cookie collection from an array of 'name' => 'value' pairs.
+     *
      * @param array $array the cookies to populate from
-     * @return self collection created from array
+     * @return static collection created from array
      */
     public static function fromArray(array $array): self
     {
@@ -282,15 +307,44 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
     }
 
     /**
+     * Adds the cookies in the collection to response and returns it.
+     *
+     * @param ResponseInterface $response
+     * @return ResponseInterface response with added cookies.
+     */
+    public function addToResponse(ResponseInterface $response): ResponseInterface
+    {
+        foreach ($this->cookies as $cookie) {
+            $response = $cookie->addToResponse($response);
+        }
+
+        return $response;
+    }
+
+    /**
+     * Creates a copy of the response with cookies set from the collection.
+     *
+     * @param ResponseInterface $response
+     * @return ResponseInterface response with new cookies.
+     */
+    public function setToResponse(ResponseInterface $response): ResponseInterface
+    {
+        $response = $response->withoutHeader('Set-Cookie');
+        return $this->addToResponse($response);
+    }
+
+    /**
      * Populates the cookie collection from a ResponseInterface.
+     *
      * @param ResponseInterface $response the response object to populate from
-     * @return self collection created from response
+     * @return static collection created from response
+     * @throws Exception
      */
     public static function fromResponse(ResponseInterface $response): self
     {
         $collection = new self();
         foreach ($response->getHeader('Set-Cookie') as $setCookieString) {
-            $cookie = Cookie::fromSetCookieString($setCookieString);
+            $cookie = Cookie::fromCookieString($setCookieString);
             $collection->add($cookie);
         }
         return $collection;

--- a/src/CookieCollection.php
+++ b/src/CookieCollection.php
@@ -144,9 +144,9 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
      * @return Cookie the cookie with the specified name. Null if the named cookie does not exist.
      * @see getValue()
      */
-    public function get(string $name): Cookie
+    public function get(string $name): ?Cookie
     {
-        return $this->cookies[$name];
+        return $this->cookies[$name] ?? null;
     }
 
     /**
@@ -238,6 +238,20 @@ final class CookieCollection implements IteratorAggregate, ArrayAccess, Countabl
         }
 
         return false;
+    }
+
+    /**
+     * Expire the cookie with the specified name
+     *
+     * @param string $name the cookie name
+     */
+    public function expire(string $name): void
+    {
+        if (!isset($this->cookies[$name])) {
+            return;
+        }
+
+        $this->cookies[$name] = $this->cookies[$name]->expire();
     }
 
     /**

--- a/src/Session/SessionMiddleware.php
+++ b/src/Session/SessionMiddleware.php
@@ -66,7 +66,7 @@ class SessionMiddleware implements MiddlewareInterface
                 ->sameSite($cookieParameters['samesite'] ?? Cookie::SAME_SITE_LAX);
 
             if ($cookieParameters['lifetime'] > 0) {
-                $sessionCookie = $sessionCookie->validFor(new \DateInterval('PT' . $cookieParameters['lifetime'] . 'S'));
+                $sessionCookie = $sessionCookie->maxAge(new \DateInterval('PT' . $cookieParameters['lifetime'] . 'S'));
             }
 
             return $sessionCookie->addToResponse($response);

--- a/src/Session/SessionMiddleware.php
+++ b/src/Session/SessionMiddleware.php
@@ -59,14 +59,14 @@ class SessionMiddleware implements MiddlewareInterface
             }
 
             $sessionCookie = (new Cookie($this->session->getName(), $currentSid))
-                ->path($cookieParameters['path'])
-                ->domain($cookieDomain)
-                ->httpOnly($cookieParameters['httponly'])
-                ->secure($useSecureCookie)
-                ->sameSite($cookieParameters['samesite'] ?? Cookie::SAME_SITE_LAX);
+                ->withPath($cookieParameters['path'])
+                ->withDomain($cookieDomain)
+                ->withHttpOnly($cookieParameters['httponly'])
+                ->withSecure($useSecureCookie)
+                ->withSameSite($cookieParameters['samesite'] ?? Cookie::SAME_SITE_LAX);
 
             if ($cookieParameters['lifetime'] > 0) {
-                $sessionCookie = $sessionCookie->maxAge(new \DateInterval('PT' . $cookieParameters['lifetime'] . 'S'));
+                $sessionCookie = $sessionCookie->withMaxAge(new \DateInterval('PT' . $cookieParameters['lifetime'] . 'S'));
             }
 
             return $sessionCookie->addToResponse($response);

--- a/tests/CookieCollectionTest.php
+++ b/tests/CookieCollectionTest.php
@@ -172,7 +172,7 @@ final class CookieCollectionTest extends TestCase
     public function testExpire(): void
     {
         $this->collection->add(new Cookie('test'));
-        $this->collection->get('test')->expire();
+        $this->collection->expire('test');
 
         $this->assertTrue($this->collection->get('test')->isExpired());
     }

--- a/tests/CookieCollectionTest.php
+++ b/tests/CookieCollectionTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Web\Tests;
+
+use Nyholm\Psr7\Response;
+use PHPUnit\Framework\TestCase;
+use Yiisoft\Yii\Web\Cookie;
+use Yiisoft\Yii\Web\CookieCollection;
+
+final class CookieCollectionTest extends TestCase
+{
+    private CookieCollection $collection;
+
+    protected function setUp(): void
+    {
+        $this->collection = new CookieCollection([]);
+    }
+
+    public function testIssetAndUnset(): void
+    {
+        $this->assertFalse(isset($this->collection['test']));
+        $this->collection->add(new Cookie('test'));
+        $this->assertTrue(isset($this->collection['test']));
+        unset($this->collection['test']);
+        $this->assertFalse(isset($this->collection['test']));
+        $this->assertCount(0, $this->collection);
+    }
+
+    public function testRemovingNonExistingEntryReturnsNull(): void
+    {
+        $this->assertEquals(null, $this->collection->remove('key_does_not_exist'));
+    }
+
+    public function testExists(): void
+    {
+        $this->collection->add(new Cookie('one', 'oneValue'));
+        $this->collection->add(new Cookie('two', 'twoValue'));
+        $exists = $this->collection->exists(static function (string $name, Cookie $cookie) {
+            return $name === 'one' && $cookie->getValue() === 'oneValue';
+        });
+        $this->assertTrue($exists);
+        $exists = $this->collection->exists(static function (string $name, Cookie $cookie) {
+            return $name === 'two' && $cookie->getValue() === 'wrongValue';
+        });
+        $this->assertFalse($exists);
+    }
+
+    public function testArrayAccess(): void
+    {
+        $cookieOne = new Cookie('one');
+        $cookieTwo = new Cookie('two');
+
+        $this->collection[] = $cookieOne;
+        $this->collection['two'] = $cookieTwo;
+
+        $this->assertEquals($cookieOne, $this->collection['one']);
+        $this->assertEquals($cookieTwo, $this->collection['two']);
+
+        $this->assertCount(2, $this->collection);
+    }
+
+    public function testContains(): void
+    {
+        $cookie = new Cookie('test');
+        $this->collection->add($cookie);
+        $this->assertTrue($this->collection->contains($cookie));
+    }
+
+    public function testGet(): void
+    {
+        $cookie = new Cookie('test');
+        $this->collection->add($cookie);
+        $this->assertEquals($cookie, $this->collection->get('test'));
+    }
+
+    public function testGetValue(): void
+    {
+        $this->collection->add(new Cookie('test', 'testVal'));
+        $this->assertEquals('testVal', $this->collection->getValue('test'));
+    }
+
+    public function testGetNames(): void
+    {
+        $this->collection->add(new Cookie('one'));
+        $this->collection->add(new Cookie('two'));
+        $this->assertEquals(['one', 'two'], $this->collection->getNames());
+    }
+
+    public function testGetCookies(): void
+    {
+        $cookieOne = new Cookie('one');
+        $cookieTwo = new Cookie('two');
+        $collection = new CookieCollection([$cookieOne, $cookieTwo]);
+        $this->assertEquals([$cookieOne, $cookieTwo], $collection->getCookies());
+    }
+
+    public function testCount(): void
+    {
+        $this->collection[] = new Cookie('one');
+        $this->collection[] = new Cookie('two');
+        $this->assertEquals(2, $this->collection->count());
+        $this->assertCount(2, $this->collection);
+    }
+
+    public function testClear(): void
+    {
+        $this->collection[] = new Cookie('one');
+        $this->collection[] = new Cookie('two');
+        $this->collection->clear();
+        $this->assertEmpty($this->collection);
+    }
+
+    public function testIsEmpty(): void
+    {
+        $this->assertTrue($this->collection->isEmpty());
+    }
+
+    public function testRemove(): void
+    {
+        $cookieOne = new Cookie('one');
+        $cookieTwo = new Cookie('two');
+        $collection = new CookieCollection([$cookieOne, $cookieTwo]);
+
+        $cookie = $collection->remove('one');
+        $this->assertEquals($cookieOne, $cookie);
+        $this->assertFalse($collection->contains($cookie));
+        $this->assertNull($collection->remove('one'));
+    }
+
+    public function testToArray(): void
+    {
+        $cookieOne = new Cookie('one');
+        $cookieTwo = new Cookie('two');
+        $collection = new CookieCollection([$cookieOne, $cookieTwo]);
+
+        $expected = ['one' => $cookieOne, 'two' => $cookieTwo];
+        $this->assertEquals($expected, $collection->toArray());
+    }
+
+    public function testIterator(): void
+    {
+        $cookieOne = new Cookie('one');
+        $cookieTwo = new Cookie('two');
+        $this->collection->add($cookieOne);
+        $this->collection->add($cookieTwo);
+
+        $this->assertIsIterable($this->collection);
+    }
+
+    public function testExpire(): void
+    {
+        $this->collection->add(new Cookie('test'));
+        $this->collection->expire('test');
+
+        $this->assertTrue($this->collection->get('test')->isExpired());
+    }
+
+    public function testFromArray(): void
+    {
+        $cookieArray = ['one' => 'oneValue', 'two' => 'twoValue'];
+        $collection = CookieCollection::fromArray($cookieArray);
+
+        $this->assertCount(2, $collection);
+        $this->assertInstanceOf(Cookie::class, $collection['one']);
+    }
+
+    public function testFromArrayWithInvalidArgument(): void
+    {
+        $cookieArray = ['one', 'two'];
+        $this->expectException(\InvalidArgumentException::class);
+        CookieCollection::fromArray($cookieArray);
+    }
+
+    public function testFromResponse(): void
+    {
+        $response = new Response();
+        $response = $response->withAddedHeader('Set-Cookie', 'one=oneValue; Path=/; Secure; HttpOnly; SameSite=Lax');
+        $response = $response->withAddedHeader('Set-Cookie', 'two=twoValue; Path=/; Secure; HttpOnly; SameSite=Lax');
+
+        $collection = CookieCollection::fromResponse($response);
+        $this->assertCount(2, $collection);
+    }
+}

--- a/tests/CookieCollectionTest.php
+++ b/tests/CookieCollectionTest.php
@@ -21,7 +21,7 @@ final class CookieCollectionTest extends TestCase
     public function testConstructorWithInvalidArray(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $collection = new CookieCollection([new Cookie('test'), 'string']);
+        new CookieCollection([new Cookie('test'), 'string']);
     }
 
     public function testIssetAndUnset(): void
@@ -191,7 +191,7 @@ final class CookieCollectionTest extends TestCase
         $cookieArray = ['one', 'two'];
 
         $this->expectException(\InvalidArgumentException::class);
-        $collection = CookieCollection::fromArray($cookieArray);
+        CookieCollection::fromArray($cookieArray);
     }
 
     public function testFromArrayWithMalformedArray(): void
@@ -199,7 +199,7 @@ final class CookieCollectionTest extends TestCase
         $cookieArray = ['one' => 'oneValue', 'two'];
 
         $this->expectException(\InvalidArgumentException::class);
-        $collection = CookieCollection::fromArray($cookieArray);
+        CookieCollection::fromArray($cookieArray);
     }
 
     public function testFromArrayWithEmptyArray(): void

--- a/tests/CookieCollectionTest.php
+++ b/tests/CookieCollectionTest.php
@@ -173,6 +173,28 @@ final class CookieCollectionTest extends TestCase
         CookieCollection::fromArray($cookieArray);
     }
 
+    public function testAddToResponse(): void
+    {
+        $response = (new Response())->withHeader('Set-Cookie', 'oldCookie=oldValue;Secure');
+        $this->collection->add(new Cookie('one', 'oneValue'));
+        $this->collection->add(new Cookie('two', 'twoValue', new \DateTimeImmutable()));
+
+        $response = $this->collection->addToResponse($response);
+        $this->assertCount(3, $response->getHeader('Set-Cookie'));
+        $this->assertEquals('oldCookie=oldValue;Secure', $response->getHeader('Set-Cookie')[0]);
+    }
+
+    public function testSetToResponse(): void
+    {
+        $response = (new Response())->withHeader('Set-Cookie', 'oldCookie=oldValue;Secure');
+        $this->collection->add(new Cookie('one', 'oneValue'));
+        $this->collection->add(new Cookie('two', 'twoValue', new \DateTimeImmutable()));
+
+        $response = $this->collection->setToResponse($response);
+        $this->assertCount(2, $response->getHeader('Set-Cookie'));
+        $this->assertEquals('one=oneValue; Path=/; Secure; HttpOnly; SameSite=Lax', $response->getHeader('Set-Cookie')[0]);
+    }
+
     public function testFromResponse(): void
     {
         $response = new Response();

--- a/tests/CookieCollectionTest.php
+++ b/tests/CookieCollectionTest.php
@@ -152,7 +152,7 @@ final class CookieCollectionTest extends TestCase
     public function testExpire(): void
     {
         $this->collection->add(new Cookie('test'));
-        $this->collection->expire('test');
+        $this->collection->get('test')->expire();
 
         $this->assertTrue($this->collection->get('test')->isExpired());
     }

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -142,7 +142,7 @@ final class CookieTest extends TestCase
         $expireDate = new \DateTimeImmutable('+60 minutes');
         $setCookieString = 'sessionId=e8bb43229de9; Domain=foo.example.com; ';
         $setCookieString .= 'Expires=' . $expireDate->format(\DateTimeInterface::RFC7231) . '; ';
-        $setCookieString .= 'Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict; ExtraKey';
+        $setCookieString .= 'Max-Age=3600; Path=/; Secure; SameSite=Strict; ExtraKey';
 
         $cookie = new Cookie(
             'sessionId',
@@ -151,7 +151,7 @@ final class CookieTest extends TestCase
             'foo.example.com',
             '/',
             true,
-            true,
+            false,
             Cookie::SAME_SITE_STRICT
         );
         $cookie2 = Cookie::fromCookieString($setCookieString);

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -21,6 +21,12 @@ class CookieTest extends TestCase
         new Cookie('test[]', 42);
     }
 
+    public function testInvalidValue(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Cookie('test', ';');
+    }
+
     public function testDefaults(): void
     {
         $cookie = new Cookie('test', 42);
@@ -32,14 +38,14 @@ class CookieTest extends TestCase
     {
         $cookie = (new Cookie('test', 42))->domain('yiiframework.com');
 
-        $this->assertSame('test=42; Path=/; Domain=yiiframework.com; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
+        $this->assertSame('test=42; Domain=yiiframework.com; Path=/; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
 
     public function testExpireAt(): void
     {
         $expireDateTime = new \DateTime();
         $expireDateTime->setTimezone(new \DateTimeZone('GMT'));
-        $formattedDateTime = $expireDateTime->format('D, d-M-Y H:i:s T');
+        $formattedDateTime = $expireDateTime->format('D, d M Y H:i:s T');
 
         $cookie = (new Cookie('test', 42))->expireAt($expireDateTime);
 
@@ -58,6 +64,12 @@ class CookieTest extends TestCase
         $cookie = (new Cookie('test', 42))->path('/test');
 
         $this->assertSame('test=42; Path=/test; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
+    }
+
+    public function testInvalidPath(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        (new Cookie('test', 42))->path(';invalid');
     }
 
     public function testSecure(): void
@@ -83,8 +95,22 @@ class CookieTest extends TestCase
 
     public function testSameSite(): void
     {
-        $cookie = (new Cookie('test', 42))->sameSite('');
+        $cookie = (new Cookie('test', 42))->sameSite(Cookie::SAME_SITE_NONE);
 
-        $this->assertSame('test=42; Path=/; Secure; HttpOnly', $this->getCookieHeader($cookie));
+        $this->assertSame('test=42; Path=/; Secure; HttpOnly; SameSite=None', $this->getCookieHeader($cookie));
+    }
+
+    public function testFromSetCookieString(): void
+    {
+        $setCookieString = 'sessionId=e8bb43229de9; Domain=foo.example.com; Path=/; Secure; HttpOnly; SameSite=Strict';
+        $cookie = (new Cookie('sessionId', 'e8bb43229de9', false))
+            ->domain('foo.example.com')
+            ->path('/')
+            ->secure(true)
+            ->httpOnly(true)
+            ->sameSite(Cookie::SAME_SITE_STRICT);
+        $cookie2 = Cookie::fromSetCookieString($setCookieString);
+
+        $this->assertSame((string)$cookie, (string)$cookie2);
     }
 }

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -6,8 +6,6 @@ use Nyholm\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use Yiisoft\Yii\Web\Cookie;
 
-use function Sodium\add;
-
 final class CookieTest extends TestCase
 {
     private function getCookieHeader(Cookie $cookie): string
@@ -23,12 +21,6 @@ final class CookieTest extends TestCase
         new Cookie('test[]', 42);
     }
 
-    public function testInvalidValue(): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        new Cookie('test', ';');
-    }
-
     public function testDefaults(): void
     {
         $cookie = new Cookie('test', 42);
@@ -36,44 +28,59 @@ final class CookieTest extends TestCase
         $this->assertSame('test=42; Path=/; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
 
-    public function testDomain(): void
+    public function testWithValue(): void
     {
-        $cookie = (new Cookie('test', 42))->domain('yiiframework.com');
-
-        $this->assertSame('test=42; Domain=yiiframework.com; Path=/; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
+        $cookie = (new Cookie('test'))->withValue(42);
+        $this->assertSame('test=42; Path=/; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
 
-    public function testExpireAt(): void
+    public function testInvalidValue(): void
     {
-        $expireDateTime = new \DateTime();
+        $this->expectException(\InvalidArgumentException::class);
+        (new Cookie('test'))->withValue(';');
+    }
+
+    public function testWithExpires(): void
+    {
+        $expireDateTime = new \DateTime('+1 year');
         $expireDateTime->setTimezone(new \DateTimeZone('GMT'));
         $formattedDateTime = $expireDateTime->format(\DateTimeInterface::RFC7231);
+        $maxAge = $expireDateTime->getTimestamp() - time();
 
-        $cookie = (new Cookie('test', 42))->expireAt($expireDateTime);
+        $cookie = (new Cookie('test', 42))->withExpires($expireDateTime);
 
-        $this->assertSame("test=42; Expires=$formattedDateTime; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
-    }
-
-    public function testMaxAge(): void
-    {
-        $maxAge = new \DateInterval('PT3600S');
-        $formattedDateTime = (new \DateTimeImmutable())->add($maxAge)->format(\DateTimeInterface::RFC7231);
-
-        $cookie = (new Cookie('test', 42))->maxAge($maxAge);
-        $this->assertSame("test=42; Expires=$formattedDateTime; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
+        $this->assertSame("test=42; Expires=$formattedDateTime; Max-Age=$maxAge; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
     }
 
     public function testIsExpired(): void
     {
-        $cookie = (new Cookie('test', 42))->expireAt((new \DateTimeImmutable('-5 years')));
+        $cookie = (new Cookie('test', 42))->withExpires((new \DateTimeImmutable('-5 years')));
         $this->assertTrue($cookie->isExpired());
     }
 
-    public function testExpire(): void
+    public function testWithMaxAge(): void
     {
-        $formattedDateTime = (new \DateTimeImmutable('-5 years'))->format(\DateTimeInterface::RFC7231);
-        $cookie = (new Cookie('test', 42))->expire();
-        $this->assertSame("test=42; Expires=$formattedDateTime; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
+        $formattedExpire = (new \DateTimeImmutable())->setTimestamp(time() + 3600)->format(\DateTimeInterface::RFC7231);
+        $cookie = (new Cookie('test', 42))->withMaxAge(new \DateInterval('PT3600S'));
+
+        $this->assertSame("test=42; Expires=$formattedExpire; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
+    }
+
+    public function testNegativeInterval(): void
+    {
+        $formattedExpire = (new \DateTimeImmutable())->setTimestamp(time() - 3600)->format(\DateTimeInterface::RFC7231);
+        $negativeInterval = new \DateInterval('PT3600S');
+        $negativeInterval->invert = 1;
+        $cookie = (new Cookie('test', 42))->withMaxAge($negativeInterval);
+
+        $this->assertSame("test=42; Expires=$formattedExpire; Max-Age=-3600; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
+    }
+
+    public function testWithDomain(): void
+    {
+        $cookie = (new Cookie('test', 42))->withDomain('yiiframework.com');
+
+        $this->assertSame('test=42; Domain=yiiframework.com; Path=/; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
 
     public function testExpireWhenBrowserIsClosed(): void
@@ -83,9 +90,9 @@ final class CookieTest extends TestCase
         $this->assertSame('test=42; Path=/; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
 
-    public function testPath(): void
+    public function testWithPath(): void
     {
-        $cookie = (new Cookie('test', 42))->path('/test');
+        $cookie = (new Cookie('test', 42))->withPath('/test');
 
         $this->assertSame('test=42; Path=/test; Secure; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
@@ -93,19 +100,19 @@ final class CookieTest extends TestCase
     public function testInvalidPath(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        (new Cookie('test', 42))->path(';invalid');
+        (new Cookie('test', 42))->withPath(';invalid');
     }
 
-    public function testSecure(): void
+    public function testWithSecure(): void
     {
-        $cookie = (new Cookie('test', 42))->secure(false);
+        $cookie = (new Cookie('test', 42))->withSecure(false);
 
         $this->assertSame('test=42; Path=/; HttpOnly; SameSite=Lax', $this->getCookieHeader($cookie));
     }
 
     public function testHttpOnly(): void
     {
-        $cookie = (new Cookie('test', 42))->httpOnly(false);
+        $cookie = (new Cookie('test', 42))->withHttpOnly(false);
 
         $this->assertSame('test=42; Path=/; Secure; SameSite=Lax', $this->getCookieHeader($cookie));
     }
@@ -114,34 +121,70 @@ final class CookieTest extends TestCase
     {
         $this->expectException(\InvalidArgumentException::class);
 
-        (new Cookie('test', 42))->sameSite('invalid');
+        (new Cookie('test', 42))->withSameSite('invalid');
     }
 
     public function testSameSiteNone(): void
     {
-        $cookie = (new Cookie('test', 42))->sameSite(Cookie::SAME_SITE_NONE);
+        $cookie = (new Cookie('test', 42))->withSameSite(Cookie::SAME_SITE_NONE);
 
         $this->assertSame('test=42; Path=/; Secure; HttpOnly; SameSite=None', $this->getCookieHeader($cookie));
     }
 
-    public function testFromSetCookieString(): void
+    public function testFromCookieString(): void
     {
-        $expireDate = new \DateTimeImmutable();
-        $maxAge = new \DateInterval('PT3600S');
+        $expireDate = (new \DateTimeImmutable())->setTimestamp(time() + 3600);
         $setCookieString = 'sessionId=e8bb43229de9; Domain=foo.example.com; ';
         $setCookieString .= 'Expires=' . $expireDate->format(\DateTimeInterface::RFC7231) . '; ';
         $setCookieString .= 'Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict';
 
-        $cookie = (new Cookie('sessionId', 'e8bb43229de9', false))
-            ->expireAt($expireDate)
-            ->maxAge($maxAge)
-            ->domain('foo.example.com')
-            ->path('/')
-            ->secure(true)
-            ->httpOnly(true)
-            ->sameSite(Cookie::SAME_SITE_STRICT);
-        $cookie2 = Cookie::fromSetCookieString($setCookieString);
+        $cookie = new Cookie(
+            'sessionId',
+            'e8bb43229de9',
+            $expireDate,
+            'foo.example.com',
+            '/',
+            true,
+            true,
+            Cookie::SAME_SITE_STRICT
+        );
+        $cookie2 = Cookie::fromCookieString($setCookieString);
 
         $this->assertSame((string)$cookie, (string)$cookie2);
+    }
+
+    public function testGetters(): void
+    {
+        $cookie = new Cookie('test', '', null, null, null, null, null, null);
+        $this->assertEquals('test', $cookie->getName());
+        $this->assertEquals('', $cookie->getValue());
+        $this->assertNull($cookie->getExpires());
+        $this->assertNull($cookie->getDomain());
+        $this->assertNull($cookie->getPath());
+        $this->assertFalse($cookie->isSecure());
+        $this->assertFalse($cookie->isHttpOnly());
+        $this->assertNull($cookie->getSameSite());
+
+        $cookie = $cookie->withValue('testValue');
+        $this->assertEquals('testValue', $cookie->getValue());
+
+        $expiry = new \DateTimeImmutable();
+        $cookie = $cookie->withExpires($expiry);
+        $this->assertEquals($expiry->getTimestamp(), $cookie->getExpires()->getTimestamp());
+
+        $cookie = $cookie->withDomain('yiiframework.com');
+        $this->assertEquals('yiiframework.com', $cookie->getDomain());
+
+        $cookie = $cookie->withPath('/path');
+        $this->assertEquals('/path', $cookie->getPath());
+
+        $cookie = $cookie->withSecure(true);
+        $this->assertTrue($cookie->isSecure());
+
+        $cookie = $cookie->withHttpOnly(true);
+        $this->assertTrue($cookie->isHttpOnly());
+
+        $cookie = $cookie->withSameSite(Cookie::SAME_SITE_LAX);
+        $this->assertEquals(Cookie::SAME_SITE_LAX, $cookie->getSameSite());
     }
 }

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -74,7 +74,6 @@ final class CookieTest extends TestCase
         $formattedDateTime = (new \DateTimeImmutable('-5 years'))->format(\DateTimeInterface::RFC7231);
         $cookie = (new Cookie('test', 42))->expire();
         $this->assertSame("test=42; Expires=$formattedDateTime; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
-
     }
 
     public function testExpireWhenBrowserIsClosed(): void

--- a/tests/CookieTest.php
+++ b/tests/CookieTest.php
@@ -66,6 +66,12 @@ final class CookieTest extends TestCase
         $this->assertSame("test=42; Expires=$formattedExpire; Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Lax", $this->getCookieHeader($cookie));
     }
 
+    public function testExpire(): void
+    {
+        $cookie = (new Cookie('test', 42))->expire();
+        $this->assertTrue($cookie->isExpired());
+    }
+
     public function testNegativeInterval(): void
     {
         $formattedExpire = (new \DateTimeImmutable())->setTimestamp(time() - 3600)->format(\DateTimeInterface::RFC7231);
@@ -133,10 +139,10 @@ final class CookieTest extends TestCase
 
     public function testFromCookieString(): void
     {
-        $expireDate = (new \DateTimeImmutable())->setTimestamp(time() + 3600);
+        $expireDate = new \DateTimeImmutable('+60 minutes');
         $setCookieString = 'sessionId=e8bb43229de9; Domain=foo.example.com; ';
         $setCookieString .= 'Expires=' . $expireDate->format(\DateTimeInterface::RFC7231) . '; ';
-        $setCookieString .= 'Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict';
+        $setCookieString .= 'Max-Age=3600; Path=/; Secure; HttpOnly; SameSite=Strict; ExtraKey';
 
         $cookie = new Cookie(
             'sessionId',
@@ -151,6 +157,12 @@ final class CookieTest extends TestCase
         $cookie2 = Cookie::fromCookieString($setCookieString);
 
         $this->assertSame((string)$cookie, (string)$cookie2);
+    }
+
+    public function testFromCookieStringWithInvalidString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Cookie::fromCookieString('');
     }
 
     public function testGetters(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️
| Tests pass?   | ✔️
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any

Some preliminary refactoring and additional class (`CookieCoolection`) needed for #86 implementation.
Also I think changes are useful even without #86.

The `Cookie` class property defaults were changed to standard cookie defaults so that minimal valid cookie can be created (containing only name and empty value) and parsed by this class and recommended/useful defaults are now set in constructor with flag switch (enabled by default).
