### PR TITLE
Use 5 bits per character for sid, to have valid cookie value

### DIFF
--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -13,7 +13,7 @@ class Session implements SessionInterface
         'use_only_cookies' => 1,
         'cookie_httponly' => 1,
         'use_strict_mode' => 1,
-        'sid_bits_per_character' => 6,
+        'sid_bits_per_character' => 5,
         'sid_length' => 48,
         'cache_limiter' => 'nocache',
         'cookie_samesite' => 'Lax',


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | #248 

Not sure why 6 bits per character was used for `sid_bits_per_character` configuration for the session. As pointed in [php documentation](https://www.php.net/manual/en/session.configuration.php#ini.session.sid-bits-per-character) 5 bits is recommended value for most environments. Anyways 6 bits per character was introducing new characters which are invalid for the cookie value, by making session id a bit more stronger.

Another way to fix this issue is to just `urlencode()` session id in `SessionMiddleware`, but I prefer not to introduce additional overhead there.

P.S. I'm planning to review `Session` class and session handling a little bit later on, and will make sure to have a way to use 6 bits per character if the user wants (but will keep 5 as default as recommended by php).