### PR TITLE
Fix using event configurator with DI references

### DIFF
--- a/src/Config/EventConfigurator.php
+++ b/src/Config/EventConfigurator.php
@@ -59,6 +59,17 @@ final class EventConfigurator extends AbstractProviderConfigurator
             return true;
         }
 
-        return is_array($definition) && array_keys($definition) === [0, 1] && in_array($definition[1], get_class_methods($definition[0]) ?? [], true);
+        if (
+            is_array($definition)
+            && array_keys($definition) === [0, 1]
+            && is_string($definition[0])
+            && $this->container->has($definition[0])
+        ) {
+            $object = $this->container->get($definition[0]);
+
+            return method_exists($object, $definition[1]);
+        }
+
+        return false;
     }
 }

--- a/src/Config/EventConfigurator.php
+++ b/src/Config/EventConfigurator.php
@@ -38,16 +38,10 @@ final class EventConfigurator extends AbstractProviderConfigurator
             }
 
             if (!is_array($listeners)) {
-                $previous = null;
-
-                try {
-                    $type = $this->isCallable($listeners) ? 'callable' : gettype($listeners);
-                } catch (InvalidListenerConfigurationException $previous) {
-                    $type = gettype($listeners);
-                }
+                $type = $this->isCallable($listeners) ? 'callable' : gettype($listeners);
                 $message = "Event listeners for $eventName must be an array, $type given.";
 
-                throw new InvalidEventConfigurationFormatException($message, 0, $previous);
+                throw new InvalidEventConfigurationFormatException($message);
             }
 
             foreach ($listeners as $callable) {

--- a/src/Config/EventConfigurator.php
+++ b/src/Config/EventConfigurator.php
@@ -6,7 +6,6 @@ namespace Yiisoft\Yii\Web\Config;
 
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
-use Psr\Container\NotFoundExceptionInterface;
 use Yiisoft\EventDispatcher\Provider\AbstractProviderConfigurator;
 use Yiisoft\EventDispatcher\Provider\Provider;
 use Yiisoft\Injector\Injector;
@@ -54,7 +53,7 @@ final class EventConfigurator extends AbstractProviderConfigurator
                             "Listener must be a callable. $type given."
                         );
                     }
-                } catch (NotFoundExceptionInterface|ContainerExceptionInterface $exception) {
+                } catch (ContainerExceptionInterface $exception) {
                     $message = "Could not instantiate event listener or listener class has invalid configuration.";
 
                     throw new InvalidListenerConfigurationException($message, 0, $exception);

--- a/src/Config/InvalidEventConfigurationFormatException.php
+++ b/src/Config/InvalidEventConfigurationFormatException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Web\Config;
+
+use InvalidArgumentException;
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
+
+class InvalidEventConfigurationFormatException extends InvalidArgumentException implements FriendlyExceptionInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string
+    {
+        return 'Configuration format passed to EventConfigurator is invalid';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSolution(): ?string
+    {
+        return <<<SOLUTION
+            EventConfigurator accepts an array in a such format:
+                [
+                    'eventName1' => [\$listener1, \$listener2, ...],
+                    'eventName2' => [\$listener3, \$listener4, ...],
+                    ...
+                ]
+        SOLUTION;
+    }
+}

--- a/src/Config/InvalidEventConfigurationFormatException.php
+++ b/src/Config/InvalidEventConfigurationFormatException.php
@@ -23,7 +23,7 @@ class InvalidEventConfigurationFormatException extends InvalidArgumentException 
     public function getSolution(): ?string
     {
         return <<<SOLUTION
-            EventConfigurator accepts an array in a such format:
+            EventConfigurator accepts an array in the following format:
                 [
                     'eventName1' => [\$listener1, \$listener2, ...],
                     'eventName2' => [\$listener3, \$listener4, ...],

--- a/src/Config/InvalidListenerConfigurationException.php
+++ b/src/Config/InvalidListenerConfigurationException.php
@@ -9,27 +9,21 @@ use Yiisoft\FriendlyException\FriendlyExceptionInterface;
 
 class InvalidListenerConfigurationException extends InvalidArgumentException implements FriendlyExceptionInterface
 {
-    /**
-     * @inheritDoc
-     */
     public function getName(): string
     {
         return 'Invalid event listener configuration';
     }
 
-    /**
-     * @inheritDoc
-     */
     public function getSolution(): ?string
     {
         return <<<SOLUTION
             Event listener has incorrect configuration. To meet EventConfigurator requirements a listener should be one of:
-            - A closure
-            - An array with an object under the 0 key and it's method under the 1 key
-            - An array with a class name under the 0 key and it's method under the 1 key
-            - An array with a string which can be converted to an object via your DI container under the 0 key and it's method under the 1 key
+            - A closure.
+            - [object, method] array.
+            - [class name, method] array.
+            - [DI container service ID, method] array.
 
-            If you are using classname or an alias string to be passed to a DI container please check if it is properly configured in the DI container.
+            If you are using a classname or an alias string to be passed to a DI container please check if it is properly configured in the DI container.
         SOLUTION;
     }
 }

--- a/src/Config/InvalidListenerConfigurationException.php
+++ b/src/Config/InvalidListenerConfigurationException.php
@@ -31,6 +31,5 @@ class InvalidListenerConfigurationException extends InvalidArgumentException imp
 
             If you are using classname or an alias string to be passed to a DI container please check if it is properly configured in the DI container.
         SOLUTION;
-
     }
 }

--- a/src/Config/InvalidListenerConfigurationException.php
+++ b/src/Config/InvalidListenerConfigurationException.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yiisoft\Yii\Web\Config;
+
+use InvalidArgumentException;
+use Yiisoft\FriendlyException\FriendlyExceptionInterface;
+
+class InvalidListenerConfigurationException extends InvalidArgumentException implements FriendlyExceptionInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getName(): string
+    {
+        return 'Invalid event listener configuration';
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSolution(): ?string
+    {
+        return <<<SOLUTION
+            Event listener has incorrect configuration. To meet EventConfigurator requirements a listener should be one of:
+            - A closure
+            - An array with an object under the 0 key and it's method under the 1 key
+            - An array with a class name under the 0 key and it's method under the 1 key
+            - An array with a string which can be converted to an object via your DI container under the 0 key and it's method under the 1 key
+
+            If you are using classname or an alias string to be passed to a DI container please check if it is properly configured in the DI container.
+        SOLUTION;
+
+    }
+}

--- a/tests/Config/EventConfiguratorTest.php
+++ b/tests/Config/EventConfiguratorTest.php
@@ -14,7 +14,7 @@ class EventConfiguratorTest extends TestCase
     {
         $event = new Event();
 
-        $container = $this->getContainer([Event::class => new Event(), 'eventAlias' => Event::class]);
+        $container = $this->getContainer([Event::class => new Event(), 'eventAlias' => new Event()]);
         $provider = new Provider();
         $configurator = new EventConfigurator($provider, $container);
         $eventConfig = $this->getEventsConfig();
@@ -22,8 +22,9 @@ class EventConfiguratorTest extends TestCase
         $listeners = iterator_to_array($provider->getListenersForEvent($event));
 
         $this->assertCount(3, $listeners);
-        $this->assertInstanceOf(\Closure::class, $listeners[0]);
-        $this->assertInstanceOf(\Closure::class, $listeners[1]);
+        foreach ($listeners as $listener) {
+            $this->assertInstanceOf(\Closure::class, $listener);
+        }
     }
 
     public function testAddEventListenerInjection(): void
@@ -80,12 +81,7 @@ class EventConfiguratorTest extends TestCase
 
             public function get($id)
             {
-                $result = $this->instances[$id];
-                if (is_string($result)) {
-                    return $this->get($result);
-                }
-
-                return $result;
+                return $this->instances[$id];
             }
 
             public function has($id)

--- a/tests/Config/EventConfiguratorTest.php
+++ b/tests/Config/EventConfiguratorTest.php
@@ -14,14 +14,14 @@ class EventConfiguratorTest extends TestCase
     {
         $event = new Event();
 
-        $container = $this->getContainer([Event::class => new Event()]);
+        $container = $this->getContainer([Event::class => new Event(), 'eventAlias' => Event::class]);
         $provider = new Provider();
         $configurator = new EventConfigurator($provider, $container);
         $eventConfig = $this->getEventsConfig();
         $configurator->registerListeners($eventConfig);
         $listeners = iterator_to_array($provider->getListenersForEvent($event));
 
-        $this->assertCount(2, $listeners);
+        $this->assertCount(3, $listeners);
         $this->assertInstanceOf(\Closure::class, $listeners[0]);
         $this->assertInstanceOf(\Closure::class, $listeners[1]);
     }
@@ -52,6 +52,7 @@ class EventConfiguratorTest extends TestCase
                 static function (Event $event) {
                     $event->register(1);
                 },
+                ['eventAlias', 'register']
             ],
         ];
     }
@@ -79,7 +80,12 @@ class EventConfiguratorTest extends TestCase
 
             public function get($id)
             {
-                return $this->instances[$id];
+                $result = $this->instances[$id];
+                if (is_string($result)) {
+                    return $this->get($result);
+                }
+
+                return $result;
             }
 
             public function has($id)


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Tests pass?   | ✔️
| Fixed issues  | ❌


Fixing usage with aliases in DI configuration:
`['someAlias' => ClassName::class]` in DI configuration and `['someALias', 'methodName']` in `events-console.php`.