### PR TITLE
proposal for different middleware dispatching flow

### DIFF
--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -21,18 +21,25 @@ use Yiisoft\Yii\Web\Event\BeforeMiddleware;
 final class MiddlewareDispatcher
 {
     /**
-     * @var \SplStack
+     * @var MiddlewareInterface[]
      */
-    private \SplStack $middlewares;
+    private array $middlewares = [];
 
     private RequestHandlerInterface $nextHandler;
     private ContainerInterface $container;
+
+    /**
+     * Contains a chain of middleware wrapped in handlers.
+     * Each handler points to the handler of middleware that will be processed next.
+     *
+     * @var RequestHandlerInterface|null stack of middleware
+     */
+    private ?RequestHandlerInterface $stack = null;
 
     public function __construct(
         ContainerInterface $container,
         RequestHandlerInterface $nextHandler = null
     ) {
-        $this->middlewares = new \SplStack();
         $this->container = $container;
         $this->nextHandler = $nextHandler ?? new NotFoundHandler($container->get(ResponseFactoryInterface::class));
     }
@@ -44,12 +51,12 @@ final class MiddlewareDispatcher
     public function addMiddleware($middleware): self
     {
         if ($middleware instanceof MiddlewareInterface) {
-            $this->middlewares->push($middleware);
+            $this->middlewares[] = $middleware;
             return $this;
         }
 
         if (is_callable($middleware)) {
-            $this->middlewares->push($this->getCallbackMiddleware($middleware, $this->container));
+            $this->middlewares[] = $this->getCallbackMiddleware($middleware, $this->container);
             return $this;
         }
 
@@ -65,52 +72,52 @@ final class MiddlewareDispatcher
         return $this->process($request, $this->nextHandler);
     }
 
-    private function process(ServerRequestInterface $request, RequestHandlerInterface $nextHandler): ResponseInterface
+    private function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $dispatcher = $this->container->get(EventDispatcherInterface::class);
+        if ($this->stack === null) {
+            $dispatcher = $this->container->get(EventDispatcherInterface::class);
 
-        return $this->createMiddlewareStackHandler($nextHandler, $dispatcher)->handle($request);
+            foreach ($this->middlewares as $middleware) {
+                $handler = $this->wrap($middleware, $handler, $dispatcher);
+            }
+            $this->stack = $handler;
+        }
+
+        return $this->stack->handle($request);
     }
 
-    private function createMiddlewareStackHandler(
-        RequestHandlerInterface $nextHandler,
+    /**
+     * Wraps handler by middlewares
+     */
+    private function wrap(
+        MiddlewareInterface $middleware,
+        RequestHandlerInterface $handler,
         EventDispatcherInterface $dispatcher
     ): RequestHandlerInterface {
-        return new class($this->middlewares, $nextHandler, $dispatcher) implements RequestHandlerInterface {
-            private ?\SplStack $stack;
-            private RequestHandlerInterface $fallbackHandler;
-            private EventDispatcherInterface $eventDispatcher;
+        return new class($middleware, $handler, $dispatcher) implements RequestHandlerInterface {
+            private MiddlewareInterface $middleware;
+            private RequestHandlerInterface $handler;
+            private EventDispatcherInterface $dispatcher;
 
-            public function __construct(\SplStack $stack, RequestHandlerInterface $fallbackHandler, EventDispatcherInterface $eventDispatcher)
-            {
-                $this->stack = clone $stack;
-                $this->fallbackHandler = $fallbackHandler;
-                $this->eventDispatcher = $eventDispatcher;
+            public function __construct(
+                MiddlewareInterface $middleware,
+                RequestHandlerInterface $handler,
+                EventDispatcherInterface $dispatcher
+            ) {
+                $this->middleware = $middleware;
+                $this->handler = $handler;
+                $this->dispatcher = $dispatcher;
             }
 
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
-                if ($this->stack === null) {
-                    throw new \RuntimeException('Middleware handler was called already');
-                }
-
-                if ($this->stack->isEmpty()) {
-                    $this->stack = null;
-                    return $this->fallbackHandler->handle($request);
-                }
-
-                /** @var MiddlewareInterface $middleware */
-                $middleware = $this->stack->pop();
-                $next = clone $this; // deep clone is not used intentionally
-                $this->stack = null; // mark queue as processed at this nesting level
-
-                $this->eventDispatcher->dispatch(new BeforeMiddleware($middleware, $request));
+                $this->dispatcher->dispatch(new BeforeMiddleware($this->middleware, $request));
 
                 $response = null;
                 try {
-                    return $response = $middleware->process($request, $next);
+                    return $response = $this->middleware->process($request, $this->handler);
                 } finally {
-                    $this->eventDispatcher->dispatch(new AfterMiddleware($middleware, $response));
+                    $this->dispatcher->dispatch(new AfterMiddleware($this->middleware, $response));
                 }
             }
         };

--- a/src/MiddlewareDispatcher.php
+++ b/src/MiddlewareDispatcher.php
@@ -91,7 +91,7 @@ final class MiddlewareDispatcher
             public function handle(ServerRequestInterface $request): ResponseInterface
             {
                 if ($this->stack === null) {
-                    throw \RuntimeException('Middleware handler was called already');
+                    throw new \RuntimeException('Middleware handler was called already');
                 }
 
                 if ($this->stack->isEmpty()) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 

Inspired by [laminas/laminas-stratigility middleware pipe](https://github.com/laminas/laminas-stratigility/blob/3.3.x/src/MiddlewarePipe.php). 

It seems to me that there is an overhead with creating the whole handler-wrapped middleware stack before handling the request. Here next handlers are created right before they're passed to the middleware process(). I used SplStack just like SplQueue is used in laminas-stratigility, I don't know whether it is more effective than simple array, but looks little bit cleaner